### PR TITLE
Let users start EPAR without installing Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ GitHub also warns against using self-hosted runners with public repositories tha
 - [Tart Provider](docs/providers/tart.md): Apple Silicon Linux VM runners.
 - [Image Build](docs/image-build.md): image internals and customization.
 - [Operations](docs/operations.md): logs, cleanup, and troubleshooting.
+- [Troubleshooting](docs/troubleshooting.md): symptom-first diagnostics by host and provider.
 - [Windows Startup](docs/advanced/windows-startup.md): start EPAR after Windows login.
 - [macOS Startup](docs/advanced/macos-startup.md): start EPAR after macOS login.
 - [Running EPAR Without Installing Go](docs/advanced/no-go-install.md): run from source with no local Go install.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The easiest path is the default **Docker-DinD** mode. It works well for most Lin
 
 Make sure these are installed:
 
-- [Go](https://go.dev/) 1.22 or newer
+- [Go](https://go.dev/) 1.22 or newer — optional; skip it if you'd rather not install Go at all (see [Running EPAR Without Installing Go](docs/advanced/no-go-install.md))
 - a Docker-compatible daemon:
   - Windows: [Docker Desktop](https://www.docker.com/products/docker-desktop/), or another Docker daemon reachable from PowerShell
   - macOS: [Docker Desktop](https://www.docker.com/products/docker-desktop/) or [OrbStack](https://orbstack.dev/)
@@ -70,6 +70,12 @@ Follow [GitHub App Setup](docs/github-app.md), then keep these three values read
 Run EPAR with the default flow:
 
 ```bash
+./start
+```
+
+On native Windows PowerShell or cmd, use `.\start.ps1` or `start.cmd` instead. Either wrapper uses Go if it's installed, and otherwise runs EPAR from source in a container with no local Go install and no binary written to disk — see [Running EPAR Without Installing Go](docs/advanced/no-go-install.md). If you'd rather call Go directly:
+
+```bash
 go run ./cmd/ephemeral-action-runner
 ```
 
@@ -90,7 +96,7 @@ Keep EPAR running while you want runners online. Stop with `Ctrl-C`; EPAR cleans
 To choose a config or runner count:
 
 ```powershell
-go run ./cmd/ephemeral-action-runner start --config .local\wsl.yml --instances 2
+.\start.ps1 --config .local\wsl.yml --instances 2
 ```
 
 If `--instances` is omitted, EPAR uses `pool.instances` from the config.
@@ -161,4 +167,5 @@ GitHub also warns against using self-hosted runners with public repositories tha
 - [Operations](docs/operations.md): logs, cleanup, and troubleshooting.
 - [Windows Startup](docs/advanced/windows-startup.md): start EPAR after Windows login.
 - [macOS Startup](docs/advanced/macos-startup.md): start EPAR after macOS login.
+- [Running EPAR Without Installing Go](docs/advanced/no-go-install.md): run from source with no local Go install.
 - [Security](docs/security.md): trust boundaries and secret handling.

--- a/README.md
+++ b/README.md
@@ -33,17 +33,13 @@ A normal long-lived self-hosted runner can leave dependencies, files, containers
 
 The easiest path is the default **Docker-DinD** mode. It works well for most Linux GitHub Actions jobs, especially Docker and Docker Compose jobs.
 
-### 1. Prerequisites
+### 1. Install Docker
 
-Make sure these are installed:
+The default quick start needs a Docker-compatible daemon:
 
-- [Go](https://go.dev/) 1.22 or newer — optional; skip it if you'd rather not install Go at all (see [Running EPAR Without Installing Go](docs/advanced/no-go-install.md))
-- a Docker-compatible daemon:
-  - Windows: [Docker Desktop](https://www.docker.com/products/docker-desktop/), or another Docker daemon reachable from PowerShell
-  - macOS: [Docker Desktop](https://www.docker.com/products/docker-desktop/) or [OrbStack](https://orbstack.dev/)
-  - Linux: [Docker Engine](https://docs.docker.com/engine/)
-
-The default [Docker-DinD](https://www.docker.com/resources/docker-in-docker-containerized-ci-workflows-dockercon-2023/) mode uses `docker run --privileged`, so the daemon must support privileged Linux containers.
+- Windows: [Docker Desktop](https://www.docker.com/products/docker-desktop/), or another Docker daemon reachable from PowerShell
+- macOS: [Docker Desktop](https://www.docker.com/products/docker-desktop/) or [OrbStack](https://orbstack.dev/)
+- Linux: [Docker Engine](https://docs.docker.com/engine/)
 
 ### 2. Download EPAR Source
 
@@ -73,11 +69,7 @@ Run EPAR with the default flow:
 ./start
 ```
 
-On native Windows PowerShell or cmd, use `.\start.ps1` or `start.cmd` instead. Either wrapper uses Go if it's installed, and otherwise runs EPAR from source in a container with no local Go install and no binary written to disk — see [Running EPAR Without Installing Go](docs/advanced/no-go-install.md). If you'd rather call Go directly:
-
-```bash
-go run ./cmd/ephemeral-action-runner
-```
+On Windows, `./start` also works in modern PowerShell. If your shell does not run it, use `.\start.ps1` or `start.cmd`.
 
 That's it.
 
@@ -95,8 +87,8 @@ Keep EPAR running while you want runners online. Stop with `Ctrl-C`; EPAR cleans
 
 To choose a config or runner count:
 
-```powershell
-.\start.ps1 --config .local\wsl.yml --instances 2
+```bash
+./start --config .local/custom-config.yml --instances 2
 ```
 
 If `--instances` is omitted, EPAR uses `pool.instances` from the config.

--- a/cmd/ephemeral-action-runner/init.go
+++ b/cmd/ephemeral-action-runner/init.go
@@ -23,7 +23,7 @@ var dockerAvailable = func(ctx context.Context) error {
 	return exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}").Run()
 }
 
-var initHostname = os.Hostname
+var initHostname = config.HostName
 
 var initRandomRead = rand.Read
 

--- a/cmd/ephemeral-action-runner/init_test.go
+++ b/cmd/ephemeral-action-runner/init_test.go
@@ -128,6 +128,26 @@ func TestGeneratedPoolNamePrefixTruncatesLongHostname(t *testing.T) {
 	}
 }
 
+func TestGeneratedPoolNamePrefixPrefersHostNameEnv(t *testing.T) {
+	oldHostname := initHostname
+	oldRandomRead := initRandomRead
+	initHostname = config.HostName
+	initRandomRead = fixedRandomRead([]byte{0xa4, 0xf9, 0xc2})
+	t.Cleanup(func() {
+		initHostname = oldHostname
+		initRandomRead = oldRandomRead
+	})
+	t.Setenv(config.HostNameEnv, "Real Windows Host")
+
+	prefix, err := generatedPoolNamePrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := prefix, "real-windows-host-a4f9c2"; got != want {
+		t.Fatalf("generatedPoolNamePrefix() = %q, want %q", got, want)
+	}
+}
+
 func TestGeneratedPoolNamePrefixFallsBackWhenHostnameIsUnavailable(t *testing.T) {
 	oldHostname := initHostname
 	oldRandomRead := initRandomRead

--- a/docs/advanced/macos-startup.md
+++ b/docs/advanced/macos-startup.md
@@ -24,7 +24,7 @@ Double-click `.local/start-epar.command` in Finder or run it from Terminal:
 The script:
 
 - finds the EPAR source folder, such as when the script lives at `.local/start-epar.command`;
-- runs EPAR with `go run ./cmd/ephemeral-action-runner`;
+- delegates to `./start`, which runs EPAR with `go run ./cmd/ephemeral-action-runner` if Go is installed and working, or a containerized `go run` if not (see [No Go Install](#no-go-install));
 - uses `.local/config.yml` by default;
 - waits for Docker to become ready before starting EPAR;
 - starts an existing `epar-dockerhub-cache` mirror container if one exists;
@@ -44,6 +44,7 @@ You can edit the copied `.local/start-epar.command` file or set environment vari
 export EPAR_ROOT="/path/to/ephemeral-action-runner"
 export EPAR_CONFIG="${EPAR_ROOT}/.local/config.yml"
 export EPAR_GO_BIN="/usr/local/go/bin/go"
+export EPAR_USE_DOCKER_RUN="auto"
 export EPAR_MIRROR_CONTAINER="epar-dockerhub-cache"
 export EPAR_WAIT_FOR_DOCKER=1
 export EPAR_DOCKER_WAIT_ATTEMPTS=120
@@ -52,6 +53,20 @@ export EPAR_DOCKER_WAIT_ATTEMPTS=120
 Set `EPAR_WAIT_FOR_DOCKER=0` only when the selected provider does not need Docker at startup.
 
 If you use the optional Docker registry mirror, create the mirror container separately. The startup script starts the container if it already exists, but it does not create or configure the mirror service.
+
+## No Go Install
+
+`start-epar.command` delegates to `./start` at the repo root. If `go` isn't on `PATH`, or the `go` found there doesn't actually run (stale/wrong-architecture installs happen — see below), `./start` runs EPAR straight from source with a containerized Go toolchain (`scripts/run-with-docker.sh`) instead of failing. No binary is built or left on disk either way. Docker is required in both cases.
+
+To force this path even when Go is installed (for example, to avoid rebuilding via `go run` on every start), set in your local copy:
+
+```bash
+export EPAR_USE_DOCKER_RUN=1
+```
+
+Set `EPAR_USE_DOCKER_RUN=0` to force `go run` locally and error out instead of falling back. See [Running EPAR Without Installing Go](no-go-install.md) for details.
+
+`./start` checks that `go version` actually runs, not just that a `go` binary exists on `PATH` — this catches a real failure mode: a stale Go install left over on `PATH` (e.g. an old Intel-only `/usr/local/go` from before an Apple Silicon migration) that segfaults instead of running. If you hit that, either remove the stale install or set `EPAR_GO_BIN`/`EPAR_USE_DOCKER_RUN` to bypass it.
 
 ## launchd Alternative
 

--- a/docs/advanced/no-go-install.md
+++ b/docs/advanced/no-go-install.md
@@ -43,6 +43,8 @@ Set `EPAR_USE_DOCKER_RUN=1` to force `./start` down this path even when Go is in
 
 The Docker wrapper passes the real host name into the toolchain container as `EPAR_HOST_NAME` so first-run defaults and generated host labels describe the machine running EPAR, not the temporary Go container. Set `EPAR_HOST_NAME` yourself before launching EPAR if you want to override that identity.
 
+The wrapper also defaults `DOCKER_CLI_HINTS=false` for its Docker calls. This suppresses Docker Desktop hint text that can otherwise appear after a normal Ctrl-C shutdown. Set `DOCKER_CLI_HINTS=true` before launching EPAR if you want Docker CLI hints during wrapper runs.
+
 ### Linux: File Ownership
 
 The container runs as root (the Go toolchain image only lets root write to its module/build cache directories). On Docker Desktop for macOS, bind-mounted files still come out owned by your normal user. On native Linux hosts, that isn't true — root-owned files would otherwise land in `.local/` and `work/`. `scripts/run-with-docker.sh` handles this by `chown`-ing those two directories back to the invoking user after each run; no action needed, but don't rely on other directories under the repo getting the same treatment.

--- a/docs/advanced/no-go-install.md
+++ b/docs/advanced/no-go-install.md
@@ -41,6 +41,8 @@ scripts/run-with-docker.sh start --config .local/config.yml
 
 Set `EPAR_USE_DOCKER_RUN=1` to force `./start` down this path even when Go is installed, or `=0` to force `go run` locally and error out instead of falling back. A Docker volume caches Go modules and build output across runs, so repeat starts are fast.
 
+The Docker wrapper passes the real host name into the toolchain container as `EPAR_HOST_NAME` so first-run defaults and generated host labels describe the machine running EPAR, not the temporary Go container. Set `EPAR_HOST_NAME` yourself before launching EPAR if you want to override that identity.
+
 ### Linux: File Ownership
 
 The container runs as root (the Go toolchain image only lets root write to its module/build cache directories). On Docker Desktop for macOS, bind-mounted files still come out owned by your normal user. On native Linux hosts, that isn't true — root-owned files would otherwise land in `.local/` and `work/`. `scripts/run-with-docker.sh` handles this by `chown`-ing those two directories back to the invoking user after each run; no action needed, but don't rely on other directories under the repo getting the same treatment.

--- a/docs/advanced/no-go-install.md
+++ b/docs/advanced/no-go-install.md
@@ -1,0 +1,77 @@
+# Running EPAR Without Installing Go
+
+The normal beta path (`go run ./cmd/ephemeral-action-runner`, see [Usage](../usage.md)) needs Go 1.22+ on the host. If you don't want to install Go, use one of the two paths below instead. Both still need Docker for the default Docker-DinD provider.
+
+| Path | What you get | Best for |
+| --- | --- | --- |
+| A: Download a release archive | A prebuilt binary from GitHub Releases | Quick trial, no Docker-in-the-loop |
+| B: Run with Docker (recommended) | Nothing persisted — source runs fresh each time via `go run` in a container | Default choice: matches the project's own source-first path, no unsigned binary ever exists on disk |
+
+## Path B: Run With Docker
+
+Run `./start` at the repo root (macOS, Linux, WSL, Git Bash) or `.\start.ps1` / `start.cmd` on native Windows PowerShell/cmd. Either uses local Go if installed and actually runnable; otherwise it runs EPAR straight from source with a containerized Go toolchain:
+
+```bash
+./start --config .local/config.yml --instances 2
+```
+
+```powershell
+.\start.ps1 --config .local\config.yml --instances 2
+```
+
+Under the hood this calls `scripts/run-with-docker.sh` (or `scripts/run-with-docker.ps1` on Windows), which builds a small local image (Go toolchain + Docker CLI, from `scripts/docker/dev.Dockerfile`) and runs:
+
+```
+docker run --rm -it \
+  -v <repo>:/app -w /app \
+  -v epar-gomod:/go/pkg/mod -v epar-gocache:/root/.cache/go-build \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  epar-dev-toolchain \
+  go run ./cmd/ephemeral-action-runner ...
+```
+
+This is `go run` — the same thing the docs recommend when Go is installed locally — just executed inside a container. **No binary is built or written to disk.** The Docker CLI baked into that small image is what lets EPAR's own runtime Docker calls (image build, container create, etc.) reach your host's Docker daemon through the mounted socket; without it, `docker run golang:1.24 go run ...` fails with "Docker is required" even with the socket mounted, because the bare `golang` image has no `docker` client binary.
+
+You can run the script directly instead of through `./start`:
+
+```bash
+scripts/run-with-docker.sh version
+scripts/run-with-docker.sh start --config .local/config.yml
+```
+
+Set `EPAR_USE_DOCKER_RUN=1` to force `./start` down this path even when Go is installed, or `=0` to force `go run` locally and error out instead of falling back. A Docker volume caches Go modules and build output across runs, so repeat starts are fast.
+
+### Linux: File Ownership
+
+The container runs as root (the Go toolchain image only lets root write to its module/build cache directories). On Docker Desktop for macOS, bind-mounted files still come out owned by your normal user. On native Linux hosts, that isn't true — root-owned files would otherwise land in `.local/` and `work/`. `scripts/run-with-docker.sh` handles this by `chown`-ing those two directories back to the invoking user after each run; no action needed, but don't rely on other directories under the repo getting the same treatment.
+
+### Windows: WSL Vs. Native PowerShell
+
+Two separate entry points, pick based on how you're working:
+
+- From WSL2, Git Bash: use `./start`. It behaves like the Linux case above (needs Docker Desktop's WSL2 integration enabled for that distro if running from WSL2).
+- From native PowerShell or cmd: use `.\start.ps1` or `start.cmd`, which use `scripts/run-with-docker.ps1` instead of the bash script.
+
+`start.ps1` and `scripts/run-with-docker.ps1` are less exercised than the bash/macOS path — if you hit an issue, check whether Docker Desktop's file sharing is enabled for the drive the repo lives on.
+
+## Path A: Download A Release Archive
+
+1. Go to the [EPAR Releases page](https://github.com/solutionforest/ephemeral-action-runner/releases) and download the archive for your OS/architecture (e.g. `ephemeral-action-runner_<version>_macos_arm64.tar.gz`).
+2. Extract it and open a terminal in the extracted folder.
+3. Run the bundled wrapper script, which handles logging and error reporting:
+   - macOS/Linux: `./run-epar`
+   - Windows: `run-epar.cmd` (double-click, or run from PowerShell/cmd)
+
+These archives are unsigned and downloaded, so macOS/Windows/antivirus are more likely to flag them than Path B's containerized `go run` (which never writes or downloads an executable). Release notes on GitHub call this out explicitly. If the OS blocks the binary, see [Unblocking The Binary](#unblocking-the-binary) below.
+
+## Unblocking The Binary
+
+Only relevant to Path A. If your OS or antivirus blocks the downloaded binary:
+
+- **macOS Gatekeeper**: right-click the binary in Finder and choose Open, then confirm in the dialog. Or clear the quarantine flag directly: `xattr -d com.apple.quarantine ./ephemeral-action-runner`.
+- **Windows SmartScreen**: click "More info" then "Run anyway" in the SmartScreen dialog, or right-click the `.exe` → Properties → check "Unblock" → OK.
+- **Windows Defender / Norton / other AV**: add an exclusion for the EPAR folder or binary path in your AV product's settings. Only do this for a binary downloaded from the official Releases page above.
+
+## macOS Login Item Startup
+
+The `.command` login item described in [macOS Startup](macos-startup.md) delegates to `./start`, so it gets the same automatic fallback. See that doc's [No Go Install](macos-startup.md#no-go-install) section for the `EPAR_USE_DOCKER_RUN` override.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,7 +41,10 @@ For Docker-DinD, cleanup removes the outer runner container with `docker rm -f -
 
 ## Troubleshooting
 
+This section is a compact checklist. For symptom-first diagnostics with host/provider-specific commands, see [Troubleshooting](troubleshooting.md).
+
 - If a Docker/browser or web/E2E image build fails before package installation, run `image update-upstream`.
+- If an image build fails with `E: You don't have enough free space in /var/cache/apt/archives/.`, check the Docker daemon or VM storage with `docker system df` and `docker run --rm gitea/runner-images:ubuntu-latest-full df -h /`. On Windows Docker Desktop with WSL2, the container-visible disk can be much smaller than Windows Explorer free space; see [Windows Docker Desktop WSL2 Disk Is Smaller Than Expected](troubleshooting.md#windows-docker-desktop-wsl2-disk-is-smaller-than-expected).
 - If Docker validation fails for a Docker-enabled image, inspect `work/logs/<image>.guest.log`.
 - If browser validation fails on ARM64, confirm `epar-browser` exists inside the guest and inspect `/opt/epar/browser`.
 - If a Docker Compose job uses an amd64-only runtime image on an ARM64 Tart runner and fails with `exec format error` or repeated container exits such as status `139`, use a runner label that supports that image instead of changing application runtime settings only for runner compatibility. Suitable targets include Docker-DinD with verified `linux/amd64` emulation, WSL x64, an x64 Linux host, or a Tart image with Rosetta enabled and validated.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,239 @@
+# Troubleshooting
+
+This page is organized by symptom, host OS, and EPAR provider. Start with the sections that match the machine and provider you are using.
+
+## Quick Diagnostics
+
+Start with the commands that match your host and provider.
+
+### All Hosts
+
+EPAR logs are written under `work/logs` by default. The latest top-level error report is usually:
+
+```text
+work/logs/epar-last-error.log
+```
+
+Image build logs use provider-specific names, for example:
+
+```text
+work/logs/epar-docker-dind-gitea-ubuntu.docker-build.log
+work/logs/epar-wsl-gitea-ubuntu.wsl-build.log
+```
+
+Check the EPAR version and selected config:
+
+```bash
+./start --help
+go run ./cmd/ephemeral-action-runner version
+```
+
+If you are running without local Go, use `./start --help`; the wrapper will run EPAR through the containerized Go toolchain.
+
+### Docker-Backed Workflows
+
+Use these on any host when the provider is Docker-DinD, when WSL image preparation starts from a Docker image, or when the no-Go wrapper is in use:
+
+```bash
+docker version
+docker info
+docker system df
+docker image ls
+```
+
+To see the free space available to containers on the active Docker daemon:
+
+```bash
+docker run --rm gitea/runner-images:ubuntu-latest-full df -h /
+```
+
+For a custom source image, replace `gitea/runner-images:ubuntu-latest-full` with the value from `image.sourceImage`.
+
+### Windows Hosts
+
+For Windows hosts that use WSL2, Docker Desktop's WSL2 backend, or the WSL provider:
+
+```powershell
+wsl --version
+wsl -l -v
+docker context ls
+docker run --rm gitea/runner-images:ubuntu-latest-full df -h /
+```
+
+`gitea/runner-images:ubuntu-latest-full` is the default source image for EPAR's default config. If your config uses a custom source image, replace it with your configured `image.sourceImage`.
+
+Docker Desktop's WSL2 backend stores Docker data in a WSL-backed virtual disk. Windows Explorer free space and container-visible free space are related, but they are not the same number.
+
+### Linux Docker Engine Hosts
+
+On native Linux, Docker data usually lives under Docker's root directory. Check it directly:
+
+```bash
+docker info --format '{{.DockerRootDir}}'
+df -h "$(docker info --format '{{.DockerRootDir}}')"
+```
+
+### macOS Docker Hosts
+
+Docker Desktop and OrbStack keep Linux container data inside their own VM/storage area. Use Docker's own view first:
+
+```bash
+docker system df
+docker run --rm gitea/runner-images:ubuntu-latest-full df -h /
+```
+
+If the container-visible disk is full, adjust or clean the Docker/OrbStack storage from that product's settings. Finder free space by itself may not reflect the Linux VM storage available to containers.
+
+## Docker Image Build Runs Out Of Space
+
+### Symptom
+
+During `start` or `image build`, the log contains:
+
+```text
+E: You don't have enough free space in /var/cache/apt/archives/.
+```
+
+or another package install fails with `No space left on device`.
+
+### What It Means
+
+This error is raised inside the temporary container or guest that is building the runner image. It usually means the Docker daemon or VM backing that build is out of writable layer space. It does not necessarily mean the host OS drive has no free space.
+
+Check the active Docker daemon:
+
+```bash
+docker run --rm gitea/runner-images:ubuntu-latest-full df -h /
+docker system df
+```
+
+If `/` inside the container is nearly full, clean up Docker data or increase the Docker VM/data-disk limit before retrying.
+
+### Cleanup Direction
+
+Review Docker's usage first:
+
+```bash
+docker system df
+docker system df -v
+```
+
+Docker prune commands remove resources that Docker considers unused. Depending on the command, that can include stopped containers, unused images, build cache, unused networks, or unused volumes. Review the Docker command help and the data on the machine before pruning, especially if you expect to restart stopped containers or keep data in Docker volumes.
+
+## Windows Docker Desktop WSL2 Disk Is Smaller Than Expected
+
+### Symptom
+
+On a Windows machine where WSL2 storage was set up before 2021, the Docker container filesystem may report about 251 GB total:
+
+```powershell
+docker run --rm gitea/runner-images:ubuntu-latest-full df -h /
+```
+
+Example:
+
+```text
+Filesystem      Size  Used Avail Use% Mounted on
+overlay         251G  211G   28G  89% /
+```
+
+On a Windows machine where WSL2 storage was set up after the 2022 WSL default-size change, the same command may report about 1007 GB total:
+
+```text
+Filesystem      Size  Used Avail Use% Mounted on
+overlay        1007G  127G  830G  14% /
+```
+
+### Why It Happens
+
+This is a Windows Docker Desktop / WSL2 storage detail, not an EPAR image-size issue. The command reports the size of Docker Desktop's Linux container storage, not the size of `gitea/runner-images:ubuntu-latest-full`.
+
+For Windows machines where WSL2 storage was set up before 2021, the default WSL2 virtual disk maximum may be about 256 GB. For WSL2 setups created after the WSL 0.58.0 change, released in 2022, Microsoft's documentation says the default maximum for each WSL2 VHD is 1 TB. This can explain why one Windows machine reports about 251 GB while another reports about 1007 GB for the container-visible filesystem.
+
+Windows Explorer free space by itself is not enough to confirm Docker has build space. The container-visible filesystem must have enough free space for the image pull, build layers, package manager cache, and final runner image.
+
+For more background, see:
+
+- <https://github.com/microsoft/WSL/issues/4373>
+- <https://learn.microsoft.com/windows/wsl/disk-space>
+- <https://docs.docker.com/desktop/features/wsl/>
+
+## Docker-DinD Build Fails With `unknown flag: --progress`
+
+### Symptom
+
+The Docker-DinD image build fails with:
+
+```text
+unknown flag: --progress
+```
+
+### What It Means
+
+This happens when the Docker client used for the build routes `docker build` through the legacy builder, or when the client does not have Buildx-style build support. It is most visible when EPAR is run through a containerized Go toolchain whose bundled Docker client differs from the host `docker.exe`.
+
+Current EPAR builds use legacy-builder-compatible Docker build arguments. If you still see this error, confirm you are running a revision that includes that fix and check which Docker client is actually executing the command:
+
+```bash
+docker version
+docker build --help
+docker buildx version
+```
+
+## Docker-DinD Startup Fails
+
+### Privileged Containers
+
+Docker-DinD requires the host Docker runtime to allow privileged Linux containers. Confirm the Docker host supports:
+
+```bash
+docker run --rm --privileged alpine:3.20 true
+```
+
+### Nested Docker Storage Driver
+
+If Docker-DinD starts but nested Docker operations fail with overlay mount errors, keep the default inner daemon storage driver:
+
+```text
+EPAR_DOCKERD_STORAGE_DRIVER=vfs
+```
+
+Use `overlay2` or `auto` in a derived image only after proving that storage driver works on the exact host runtime.
+
+## WSL Provider Image Build Fails Early
+
+This section applies to Windows hosts using `provider.type: wsl`.
+
+If the default WSL image build fails before importing or starting the temporary distro, confirm Docker is reachable because the default WSL full image converts a Docker image into a rootfs tar:
+
+```powershell
+docker version
+docker pull gitea/runner-images:ubuntu-latest-full
+wsl -l -v
+```
+
+If the WSL image build fails after import but before systemd is ready, inspect:
+
+```text
+work/logs/<image>.wsl-build.log
+work/logs/<temporary-distro>.guest.log
+```
+
+## GitHub Runner Registration Fails
+
+Confirm the GitHub App has organization self-hosted runner read/write permission and that the private key path in the config is readable from the EPAR process:
+
+```yaml
+github:
+  appId: 123456
+  organization: your-org
+  privateKeyPath: .local/github-app.pem
+```
+
+If stale runner records remain after an interrupted run:
+
+```bash
+go run ./cmd/ephemeral-action-runner cleanup
+```
+
+Cleanup only targets runner names matching `pool.namePrefix`, so keep that prefix unique per machine/config within the GitHub organization.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,8 +12,8 @@ Install the host tools you need:
 
 | Required for | Tool |
 | --- | --- |
-| Source ZIP quick start | Go 1.22 or newer |
-| Local binary build | Go 1.22 or newer |
+| Source ZIP quick start | Go 1.22 or newer, or Docker (see [no-Go-install](advanced/no-go-install.md)) |
+| Local binary build | Go 1.22 or newer, or Docker (see [no-Go-install](advanced/no-go-install.md)) |
 | Updating the pinned `actions/runner-images` checkout | Git |
 | macOS provider | Tart |
 | Windows provider | WSL2 |
@@ -51,9 +51,17 @@ go build -o ./bin/ephemeral-action-runner ./cmd/ephemeral-action-runner
 
 The examples below use `go run ./cmd/ephemeral-action-runner` for the public source-first path. If you built a local binary, use `./bin/ephemeral-action-runner` or `.\bin\ephemeral-action-runner.exe` instead.
 
+Don't want to install Go at all? See [Running EPAR Without Installing Go](advanced/no-go-install.md) for running from source in a container, or downloading a prebuilt release binary.
+
 ## One-Command Start
 
-For the default Docker-DinD setup, run EPAR from the source folder:
+For the default Docker-DinD setup, run EPAR from the source folder. On macOS, Linux, WSL, or Git Bash, use the `./start` wrapper; on native Windows PowerShell/cmd, use `.\start.ps1` or `start.cmd`. Either uses Go if installed, and otherwise runs EPAR from source with a containerized Go toolchain automatically, with no binary written to disk (see [Running EPAR Without Installing Go](advanced/no-go-install.md)):
+
+```bash
+./start
+```
+
+Equivalent without the wrapper:
 
 ```bash
 go run ./cmd/ephemeral-action-runner
@@ -61,13 +69,25 @@ go run ./cmd/ephemeral-action-runner
 
 If no config exists, EPAR starts the initializer, asks for the GitHub App ID, organization, and private key path, then writes `.local/config.yml`. It then checks the configured image, builds or replaces it when the image is missing or no longer matches the config, and starts the configured number of runners. The default config uses `pool.instances: 1`.
 
-Use `start` when you want to choose a config or runner count:
+Pass flags through `./start` to choose a config or runner count:
+
+```bash
+./start --config .local/config.yml --instances 2
+```
+
+Equivalent without the wrapper:
 
 ```bash
 go run ./cmd/ephemeral-action-runner start --config .local/config.yml --instances 2
 ```
 
 On Windows PowerShell:
+
+```powershell
+.\start.ps1 --config .local\wsl.yml --instances 2
+```
+
+Equivalent without the wrapper:
 
 ```powershell
 go run ./cmd/ephemeral-action-runner start --config .local\wsl.yml --instances 2

--- a/examples/macos/start-epar.command
+++ b/examples/macos/start-epar.command
@@ -28,19 +28,12 @@ find_repo_root() {
 
 EPAR_ROOT="$(find_repo_root)"
 CONFIG_PATH="${EPAR_CONFIG:-${EPAR_ROOT}/.local/config.yml}"
-GO_BIN="${EPAR_GO_BIN:-go}"
 MIRROR_CONTAINER="${EPAR_MIRROR_CONTAINER:-epar-dockerhub-cache}"
 WAIT_FOR_DOCKER="${EPAR_WAIT_FOR_DOCKER:-1}"
 DOCKER_WAIT_ATTEMPTS="${EPAR_DOCKER_WAIT_ATTEMPTS:-120}"
 
 cd "${EPAR_ROOT}"
 mkdir -p work/logs
-
-if ! command -v "${GO_BIN}" >/dev/null 2>&1; then
-  echo "Go not found: ${GO_BIN}" >&2
-  echo "Install Go, or set EPAR_GO_BIN to the full path of the go executable." >&2
-  exit 1
-fi
 
 if [[ "${WAIT_FOR_DOCKER}" != "0" ]]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] waiting for Docker to become ready..."
@@ -63,4 +56,6 @@ if [[ "${WAIT_FOR_DOCKER}" != "0" ]]; then
 fi
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] starting EPAR..."
-exec "${GO_BIN}" run ./cmd/ephemeral-action-runner start --config "${CONFIG_PATH}" "$@"
+# Go-detection and the containerized-Go fallback live in ./start (single
+# source of truth). Set EPAR_GO_BIN / EPAR_USE_DOCKER_RUN above to override.
+exec "${EPAR_ROOT}/start" --config "${CONFIG_PATH}" "$@"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,7 @@ const (
 	ImageSourceDockerImage = "docker-image"
 	ImageSourceRootFSTar   = "rootfs-tar"
 	MaxRunnerLabelLength   = 256
+	HostNameEnv            = "EPAR_HOST_NAME"
 )
 
 func Default() Config {
@@ -367,11 +368,18 @@ func applyProviderDefaults(cfg *Config, explicit map[string]bool) {
 
 var osHostname = os.Hostname
 
+func HostName() (string, error) {
+	if hostname := strings.TrimSpace(os.Getenv(HostNameEnv)); hostname != "" {
+		return hostname, nil
+	}
+	return osHostname()
+}
+
 func applyRunnerHostLabel(cfg *Config) {
 	if !cfg.Runner.IncludeHostLabel {
 		return
 	}
-	hostname, err := osHostname()
+	hostname, err := HostName()
 	if err != nil {
 		return
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,7 @@ func TestLoadYAMLSubset(t *testing.T) {
 	oldHostname := osHostname
 	osHostname = func() (string, error) { return "CI Box 01", nil }
 	t.Cleanup(func() { osHostname = oldHostname })
+	t.Setenv(HostNameEnv, "")
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
@@ -77,6 +78,7 @@ func TestRunnerHostLabelDefaultsToEnabled(t *testing.T) {
 	oldHostname := osHostname
 	osHostname = func() (string, error) { return "Build Box_01.example", nil }
 	t.Cleanup(func() { osHostname = oldHostname })
+	t.Setenv(HostNameEnv, "")
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
@@ -95,10 +97,34 @@ provider:
 	}
 }
 
+func TestRunnerHostLabelPrefersHostNameEnv(t *testing.T) {
+	oldHostname := osHostname
+	osHostname = func() (string, error) { return "container-id", nil }
+	t.Cleanup(func() { osHostname = oldHostname })
+	t.Setenv(HostNameEnv, "Real Windows Host")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(path, []byte(`
+provider:
+  type: docker-dind
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.Runner.Labels[len(cfg.Runner.Labels)-1], "epar-host-real-windows-host"; got != want {
+		t.Fatalf("host label = %q, want %q", got, want)
+	}
+}
+
 func TestRunnerHostLabelCanBeDisabled(t *testing.T) {
 	oldHostname := osHostname
 	osHostname = func() (string, error) { return "build-box", nil }
 	t.Cleanup(func() { osHostname = oldHostname })
+	t.Setenv(HostNameEnv, "")
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
@@ -125,6 +151,7 @@ func TestRunnerHostLabelDoesNotDuplicateExistingLabel(t *testing.T) {
 	oldHostname := osHostname
 	osHostname = func() (string, error) { return "Build Box", nil }
 	t.Cleanup(func() { osHostname = oldHostname })
+	t.Setenv(HostNameEnv, "")
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
@@ -392,6 +419,7 @@ func TestExampleConfigsLoadAndValidate(t *testing.T) {
 	oldHostname := osHostname
 	osHostname = func() (string, error) { return "Example Host", nil }
 	t.Cleanup(func() { osHostname = oldHostname })
+	t.Setenv(HostNameEnv, "")
 
 	entries, err := os.ReadDir(filepath.Join("..", "..", "configs"))
 	if err != nil {

--- a/internal/pool/image.go
+++ b/internal/pool/image.go
@@ -126,7 +126,7 @@ func (m *Manager) buildDockerDindImage(ctx context.Context, opts ImageBuildOptio
 	}
 	fmt.Printf("building Docker-DinD image %s from %s\n", m.Config.Image.OutputImage, m.Config.Image.SourceImage)
 	fmt.Printf("log: %s\n", buildLogPath)
-	args := []string{"build", "--progress=plain", "-t", m.Config.Image.OutputImage}
+	args := []string{"build", "-t", m.Config.Image.OutputImage}
 	if m.Config.Provider.Platform != "" {
 		args = append(args, "--platform", m.Config.Provider.Platform)
 	}

--- a/internal/pool/image_test.go
+++ b/internal/pool/image_test.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -91,6 +92,53 @@ func TestDockerDindDockerfileRunsBuildStepsAsRoot(t *testing.T) {
 	}
 }
 
+func TestDockerDindBuildUsesLegacyBuilderCompatibleArgs(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(root, "scripts", "guest", "ubuntu"),
+		filepath.Join(root, "scripts", "container", "ubuntu"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manager := Manager{
+		Config: config.Config{
+			Image: config.ImageConfig{
+				SourceImage:   "gitea/runner-images:ubuntu-latest-full",
+				OutputImage:   "epar-docker-dind-gitea-ubuntu",
+				RunnerVersion: "latest",
+			},
+			Pool:     config.PoolConfig{LogDir: "logs"},
+			Provider: config.ProviderConfig{Type: "docker-dind", Platform: "linux/amd64"},
+		},
+		ProjectRoot: root,
+		DryRun:      true,
+	}
+	manifest := ImageManifest{
+		SchemaVersion: imageManifestSchemaVersion,
+		ProviderType:  "docker-dind",
+		SourceType:    config.ImageSourceDockerImage,
+		SourceImage:   "gitea/runner-images:ubuntu-latest-full",
+		OutputImage:   "epar-docker-dind-gitea-ubuntu",
+		RunnerVersion: "latest",
+	}
+
+	out, err := capturePoolStdout(t, func() error {
+		return manager.buildDockerDindImage(context.Background(), ImageBuildOptions{Replace: true, Manifest: &manifest}, filepath.Join(root, "third_party", "runner-images"))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "--progress") {
+		t.Fatalf("docker build command should not require BuildKit progress support:\n%s", out)
+	}
+	if !strings.Contains(out, "docker build -t epar-docker-dind-gitea-ubuntu --platform linux/amd64") {
+		t.Fatalf("docker build command missing expected base args:\n%s", out)
+	}
+}
+
 func TestInstallCustomScriptsRunsInOrder(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".local"), 0755); err != nil {
@@ -129,6 +177,30 @@ func TestInstallCustomScriptsRunsInOrder(t *testing.T) {
 	if !reflect.DeepEqual(runCommands, want) {
 		t.Fatalf("custom script run commands = %#v, want %#v", runCommands, want)
 	}
+}
+
+func capturePoolStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fnErr := fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out), fnErr
 }
 
 func TestRelativeCustomInstallScriptCannotEscapeProjectRoot(t *testing.T) {

--- a/scripts/docker/dev.Dockerfile
+++ b/scripts/docker/dev.Dockerfile
@@ -1,0 +1,6 @@
+# Go toolchain + Docker CLI, for running EPAR from source with no local Go
+# install (scripts/run-with-docker.sh). The Docker CLI lets EPAR's own
+# runtime docker calls reach the host daemon over the mounted socket.
+ARG GO_IMAGE=golang:1.24
+FROM ${GO_IMAGE}
+COPY --from=docker:27-cli /usr/local/bin/docker /usr/local/bin/docker

--- a/scripts/run-with-docker.ps1
+++ b/scripts/run-with-docker.ps1
@@ -20,6 +20,21 @@ $DevImage = if ($env:EPAR_DEV_IMAGE) { $env:EPAR_DEV_IMAGE } else { "epar-dev-to
 $GomodVolume = if ($env:EPAR_GOMOD_VOLUME) { $env:EPAR_GOMOD_VOLUME } else { "epar-gomod" }
 $GocacheVolume = if ($env:EPAR_GOCACHE_VOLUME) { $env:EPAR_GOCACHE_VOLUME } else { "epar-gocache" }
 $DockerSock = if ($env:EPAR_DOCKER_SOCK) { $env:EPAR_DOCKER_SOCK } else { "/var/run/docker.sock" }
+$HostName = $env:EPAR_HOST_NAME
+if (-not $HostName) {
+    $HostName = $env:COMPUTERNAME
+}
+if (-not $HostName) {
+    try {
+        $HostName = [System.Net.Dns]::GetHostName()
+    } catch {
+        $HostName = ""
+    }
+}
+$DockerEnvFlags = @()
+if ($HostName) {
+    $DockerEnvFlags += @("-e", "EPAR_HOST_NAME=$HostName")
+}
 
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     Write-Error "docker command not found. Install Docker Desktop or another working Docker host."
@@ -27,6 +42,14 @@ if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
 }
 
 $RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$DockerRunFlags = @("--rm", "-i")
+try {
+    if (-not [Console]::IsInputRedirected) {
+        $DockerRunFlags += "-t"
+    }
+} catch {
+    # Non-console PowerShell hosts can throw here; keep stdin attached without a TTY.
+}
 
 docker build --quiet `
     --build-arg "GO_IMAGE=$Image" `
@@ -35,7 +58,8 @@ docker build --quiet `
     (Join-Path $RepoRoot "scripts\docker") | Out-Null
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-docker run --rm -i `
+docker run @DockerRunFlags `
+    @DockerEnvFlags `
     -v "${RepoRoot}:/app" -w /app `
     -v "${GomodVolume}:/go/pkg/mod" `
     -v "${GocacheVolume}:/root/.cache/go-build" `

--- a/scripts/run-with-docker.ps1
+++ b/scripts/run-with-docker.ps1
@@ -20,6 +20,10 @@ $DevImage = if ($env:EPAR_DEV_IMAGE) { $env:EPAR_DEV_IMAGE } else { "epar-dev-to
 $GomodVolume = if ($env:EPAR_GOMOD_VOLUME) { $env:EPAR_GOMOD_VOLUME } else { "epar-gomod" }
 $GocacheVolume = if ($env:EPAR_GOCACHE_VOLUME) { $env:EPAR_GOCACHE_VOLUME } else { "epar-gocache" }
 $DockerSock = if ($env:EPAR_DOCKER_SOCK) { $env:EPAR_DOCKER_SOCK } else { "/var/run/docker.sock" }
+$OriginalDockerCliHintsExists = Test-Path Env:DOCKER_CLI_HINTS
+$OriginalDockerCliHints = $env:DOCKER_CLI_HINTS
+$DockerCliHints = if ($OriginalDockerCliHints) { $OriginalDockerCliHints } else { "false" }
+$env:DOCKER_CLI_HINTS = $DockerCliHints
 $HostName = $env:EPAR_HOST_NAME
 if (-not $HostName) {
     $HostName = $env:COMPUTERNAME
@@ -32,6 +36,7 @@ if (-not $HostName) {
     }
 }
 $DockerEnvFlags = @()
+$DockerEnvFlags += @("-e", "DOCKER_CLI_HINTS=$DockerCliHints")
 if ($HostName) {
     $DockerEnvFlags += @("-e", "EPAR_HOST_NAME=$HostName")
 }
@@ -51,20 +56,34 @@ try {
     # Non-console PowerShell hosts can throw here; keep stdin attached without a TTY.
 }
 
-docker build --quiet `
-    --build-arg "GO_IMAGE=$Image" `
-    -t $DevImage `
-    -f (Join-Path $RepoRoot "scripts\docker\dev.Dockerfile") `
-    (Join-Path $RepoRoot "scripts\docker") | Out-Null
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$ExitCode = 0
+try {
+    docker build --quiet `
+        --build-arg "GO_IMAGE=$Image" `
+        -t $DevImage `
+        -f (Join-Path $RepoRoot "scripts\docker\dev.Dockerfile") `
+        (Join-Path $RepoRoot "scripts\docker") | Out-Null
 
-docker run @DockerRunFlags `
-    @DockerEnvFlags `
-    -v "${RepoRoot}:/app" -w /app `
-    -v "${GomodVolume}:/go/pkg/mod" `
-    -v "${GocacheVolume}:/root/.cache/go-build" `
-    -v "${DockerSock}:/var/run/docker.sock" `
-    $DevImage `
-    go run ./cmd/ephemeral-action-runner @EparArgs
+    if ($LASTEXITCODE -ne 0) {
+        $ExitCode = $LASTEXITCODE
+    } else {
+        docker run @DockerRunFlags `
+            @DockerEnvFlags `
+            -v "${RepoRoot}:/app" -w /app `
+            -v "${GomodVolume}:/go/pkg/mod" `
+            -v "${GocacheVolume}:/root/.cache/go-build" `
+            -v "${DockerSock}:/var/run/docker.sock" `
+            $DevImage `
+            go run ./cmd/ephemeral-action-runner @EparArgs
 
-exit $LASTEXITCODE
+        $ExitCode = $LASTEXITCODE
+    }
+} finally {
+    if ($OriginalDockerCliHintsExists) {
+        $env:DOCKER_CLI_HINTS = $OriginalDockerCliHints
+    } else {
+        Remove-Item Env:DOCKER_CLI_HINTS -ErrorAction SilentlyContinue
+    }
+}
+
+exit $ExitCode

--- a/scripts/run-with-docker.ps1
+++ b/scripts/run-with-docker.ps1
@@ -1,0 +1,46 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $EparArgs
+)
+
+# Runs EPAR from source with no local Go install: a containerized Go
+# toolchain compiles and executes the source with `go run`, the same as the
+# documented source-first path (docs/usage.md) - just inside a container
+# instead of on the host. No binary is built or left on disk.
+#
+# Docker is still required (both for this wrapper and for EPAR's own
+# Docker-DinD provider, reached here via the mounted host socket).
+#
+# Usage: scripts\run-with-docker.ps1 [epar-args...]
+
+$ErrorActionPreference = "Stop"
+
+$Image = if ($env:GO_DOCKER_IMAGE) { $env:GO_DOCKER_IMAGE } else { "golang:1.24" }
+$DevImage = if ($env:EPAR_DEV_IMAGE) { $env:EPAR_DEV_IMAGE } else { "epar-dev-toolchain" }
+$GomodVolume = if ($env:EPAR_GOMOD_VOLUME) { $env:EPAR_GOMOD_VOLUME } else { "epar-gomod" }
+$GocacheVolume = if ($env:EPAR_GOCACHE_VOLUME) { $env:EPAR_GOCACHE_VOLUME } else { "epar-gocache" }
+$DockerSock = if ($env:EPAR_DOCKER_SOCK) { $env:EPAR_DOCKER_SOCK } else { "/var/run/docker.sock" }
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "docker command not found. Install Docker Desktop or another working Docker host."
+    exit 1
+}
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+docker build --quiet `
+    --build-arg "GO_IMAGE=$Image" `
+    -t $DevImage `
+    -f (Join-Path $RepoRoot "scripts\docker\dev.Dockerfile") `
+    (Join-Path $RepoRoot "scripts\docker") | Out-Null
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+docker run --rm -i `
+    -v "${RepoRoot}:/app" -w /app `
+    -v "${GomodVolume}:/go/pkg/mod" `
+    -v "${GocacheVolume}:/root/.cache/go-build" `
+    -v "${DockerSock}:/var/run/docker.sock" `
+    $DevImage `
+    go run ./cmd/ephemeral-action-runner @EparArgs
+
+exit $LASTEXITCODE

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -16,6 +16,14 @@ dev_image="${EPAR_DEV_IMAGE:-epar-dev-toolchain}"
 gomod_volume="${EPAR_GOMOD_VOLUME:-epar-gomod}"
 gocache_volume="${EPAR_GOCACHE_VOLUME:-epar-gocache}"
 docker_sock="${EPAR_DOCKER_SOCK:-/var/run/docker.sock}"
+host_name="${EPAR_HOST_NAME:-}"
+if [[ -z "${host_name}" ]]; then
+  host_name="$(hostname 2>/dev/null || true)"
+fi
+docker_env_flags=()
+if [[ -n "${host_name}" ]]; then
+  docker_env_flags=(-e "EPAR_HOST_NAME=${host_name}")
+fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker command not found. Install Docker Desktop, Docker Engine, or a compatible Docker host." >&2
@@ -31,7 +39,7 @@ docker build --quiet \
   "${repo_root}/scripts/docker" >/dev/null
 
 tty_flags=(--rm -i)
-if [[ -t 0 && -t 1 ]]; then
+if [[ -t 0 ]]; then
   tty_flags=(--rm -it)
 fi
 
@@ -43,6 +51,7 @@ fi
 # bind-mounted .local/ and work/ dirs, so hand them back to the invoking user
 # afterward.
 docker run "${tty_flags[@]}" \
+  "${docker_env_flags[@]}" \
   -v "${repo_root}:/app" -w /app \
   -v "${gomod_volume}:/go/pkg/mod" \
   -v "${gocache_volume}:/root/.cache/go-build" \

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs EPAR from source with no local Go install: a containerized Go
+# toolchain compiles and executes the source with `go run`, the same as the
+# documented source-first path (docs/usage.md) — just inside a container
+# instead of on the host. No binary is built or left on disk.
+#
+# Docker is still required (both for this wrapper and for EPAR's own
+# Docker-DinD provider, reached here via the mounted host socket).
+#
+# Usage: scripts/run-with-docker.sh [epar-args...]
+
+image="${GO_DOCKER_IMAGE:-golang:1.24}"
+dev_image="${EPAR_DEV_IMAGE:-epar-dev-toolchain}"
+gomod_volume="${EPAR_GOMOD_VOLUME:-epar-gomod}"
+gocache_volume="${EPAR_GOCACHE_VOLUME:-epar-gocache}"
+docker_sock="${EPAR_DOCKER_SOCK:-/var/run/docker.sock}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker command not found. Install Docker Desktop, Docker Engine, or a compatible Docker host." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+docker build --quiet \
+  --build-arg "GO_IMAGE=${image}" \
+  -t "$dev_image" \
+  -f "${repo_root}/scripts/docker/dev.Dockerfile" \
+  "${repo_root}/scripts/docker" >/dev/null
+
+tty_flags=(--rm -i)
+if [[ -t 0 && -t 1 ]]; then
+  tty_flags=(--rm -it)
+fi
+
+# The container runs as root (needed: GOPATH/GOCACHE named volumes and /root
+# are only writable by root inside the golang image, and re-pointing them at
+# a writable path just to run as a non-root UID isn't worth the complexity).
+# On real Linux hosts (unlike Docker Desktop, which already maps bind-mount
+# ownership back to the host user) that leaves root-owned files under the
+# bind-mounted .local/ and work/ dirs, so hand them back to the invoking user
+# afterward.
+docker run "${tty_flags[@]}" \
+  -v "${repo_root}:/app" -w /app \
+  -v "${gomod_volume}:/go/pkg/mod" \
+  -v "${gocache_volume}:/root/.cache/go-build" \
+  -v "${docker_sock}:/var/run/docker.sock" \
+  "$dev_image" \
+  go run ./cmd/ephemeral-action-runner "$@" && status=0 || status=$?
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  chown -R "$(id -u):$(id -g)" "${repo_root}/.local" "${repo_root}/work" 2>/dev/null || true
+fi
+
+exit "$status"

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -16,13 +16,14 @@ dev_image="${EPAR_DEV_IMAGE:-epar-dev-toolchain}"
 gomod_volume="${EPAR_GOMOD_VOLUME:-epar-gomod}"
 gocache_volume="${EPAR_GOCACHE_VOLUME:-epar-gocache}"
 docker_sock="${EPAR_DOCKER_SOCK:-/var/run/docker.sock}"
+export DOCKER_CLI_HINTS="${DOCKER_CLI_HINTS:-false}"
 host_name="${EPAR_HOST_NAME:-}"
 if [[ -z "${host_name}" ]]; then
   host_name="$(hostname 2>/dev/null || true)"
 fi
-docker_env_flags=()
+docker_env_flags=(-e "DOCKER_CLI_HINTS=${DOCKER_CLI_HINTS}")
 if [[ -n "${host_name}" ]]; then
-  docker_env_flags=(-e "EPAR_HOST_NAME=${host_name}")
+  docker_env_flags+=(-e "EPAR_HOST_NAME=${host_name}")
 fi
 
 if ! command -v docker >/dev/null 2>&1; then

--- a/start
+++ b/start
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-command start: ./start or ./start --config .local/config.yml --instances 2
+#
+# Uses local Go if present. Otherwise runs EPAR from source inside a
+# containerized Go toolchain via `go run` (no local Go install needed, and
+# no binary is built or left on disk). Docker is required either way.
+# See docs/advanced/no-go-install.md.
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+cd "${script_dir}"
+
+GO_BIN="${EPAR_GO_BIN:-go}"
+USE_DOCKER_RUN="${EPAR_USE_DOCKER_RUN:-auto}"
+
+# A present-but-broken `go` (wrong architecture, ancient pre-modules install
+# left over on PATH, etc.) must not look "usable" just because it exists.
+go_usable() {
+  command -v "$1" >/dev/null 2>&1 && "$1" version >/dev/null 2>&1
+}
+
+if [[ "${USE_DOCKER_RUN}" == "1" ]] || { [[ "${USE_DOCKER_RUN}" == "auto" ]] && ! go_usable "${GO_BIN}"; }; then
+  echo "Go not found or not runnable (or EPAR_USE_DOCKER_RUN=1); running with a containerized Go toolchain instead..." >&2
+  exec "${script_dir}/scripts/run-with-docker.sh" start "$@"
+fi
+
+if ! go_usable "${GO_BIN}"; then
+  echo "Go not found or not runnable: ${GO_BIN}" >&2
+  echo "Install Go, set EPAR_GO_BIN, or set EPAR_USE_DOCKER_RUN=1 to run with a containerized Go toolchain instead." >&2
+  echo "See docs/advanced/no-go-install.md." >&2
+  exit 1
+fi
+
+exec "${GO_BIN}" run ./cmd/ephemeral-action-runner start "$@"

--- a/start.cmd
+++ b/start.cmd
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0start.ps1" %*
+
+exit /b %ERRORLEVEL%

--- a/start.ps1
+++ b/start.ps1
@@ -16,6 +16,10 @@ Set-Location -LiteralPath $Root
 
 $GoBin = if ($env:EPAR_GO_BIN) { $env:EPAR_GO_BIN } else { "go" }
 $UseDockerRun = if ($env:EPAR_USE_DOCKER_RUN) { $env:EPAR_USE_DOCKER_RUN } else { "auto" }
+$StartArgs = @("start")
+if ($null -ne $EparArgs -and $EparArgs.Count -gt 0) {
+    $StartArgs += $EparArgs
+}
 
 function Test-GoUsable {
     param([string]$GoBin)
@@ -32,7 +36,7 @@ $goUsable = Test-GoUsable -GoBin $GoBin
 
 if ($UseDockerRun -eq "1" -or ($UseDockerRun -eq "auto" -and -not $goUsable)) {
     Write-Warning "Go not found or not runnable (or EPAR_USE_DOCKER_RUN=1); running with a containerized Go toolchain instead..."
-    & (Join-Path $Root "scripts\run-with-docker.ps1") "start" @EparArgs
+    & (Join-Path $Root "scripts\run-with-docker.ps1") @StartArgs
     exit $LASTEXITCODE
 }
 
@@ -41,5 +45,5 @@ if (-not $goUsable) {
     exit 1
 }
 
-& $GoBin run ./cmd/ephemeral-action-runner start @EparArgs
+& $GoBin run ./cmd/ephemeral-action-runner @StartArgs
 exit $LASTEXITCODE

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,45 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $EparArgs
+)
+
+# One-command start: .\start.ps1 or .\start.ps1 --config .local\config.yml --instances 2
+#
+# Uses local Go if present and actually runnable. Otherwise runs EPAR from
+# source inside a containerized Go toolchain via `go run` (no local Go
+# install needed, and no binary is built or left on disk). Docker is
+# required either way. See docs/advanced/no-go-install.md.
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location -LiteralPath $Root
+
+$GoBin = if ($env:EPAR_GO_BIN) { $env:EPAR_GO_BIN } else { "go" }
+$UseDockerRun = if ($env:EPAR_USE_DOCKER_RUN) { $env:EPAR_USE_DOCKER_RUN } else { "auto" }
+
+function Test-GoUsable {
+    param([string]$GoBin)
+    if (-not (Get-Command $GoBin -ErrorAction SilentlyContinue)) { return $false }
+    try {
+        & $GoBin version *> $null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+$goUsable = Test-GoUsable -GoBin $GoBin
+
+if ($UseDockerRun -eq "1" -or ($UseDockerRun -eq "auto" -and -not $goUsable)) {
+    Write-Warning "Go not found or not runnable (or EPAR_USE_DOCKER_RUN=1); running with a containerized Go toolchain instead..."
+    & (Join-Path $Root "scripts\run-with-docker.ps1") "start" @EparArgs
+    exit $LASTEXITCODE
+}
+
+if (-not $goUsable) {
+    Write-Error "Go not found or not runnable: $GoBin`nInstall Go, set EPAR_GO_BIN, or set EPAR_USE_DOCKER_RUN=1 to run with a containerized Go toolchain instead.`nSee docs/advanced/no-go-install.md."
+    exit 1
+}
+
+& $GoBin run ./cmd/ephemeral-action-runner start @EparArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- Add `./start` (plus `start.ps1`/`start.cmd` for native Windows) as a one-command entry point: uses local Go when present and actually runnable, otherwise runs EPAR from source inside a containerized Go toolchain via `go run` — no binary ever written to disk.
- Harden the containerized fallback path: keep the Docker wrapper interactive/TTY-aware, pass the host machine name through for stable pool prefixes, avoid passing an empty trailing arg from `start.ps1`, and suppress Docker CLI hint noise.
- `./start` checks that `go version` actually succeeds (not just that a `go` binary is on PATH), since a stale/wrong-arch Go install segfaults instead of failing cleanly.
- On Linux, hand file ownership of `.local/` and `work/` back to the invoking user after each containerized run, since the container runs as root and Docker Desktop's host-ownership mapping doesn't apply there.
- `examples/macos/start-epar.command` now delegates to `./start` instead of duplicating Go-detection logic.
- Add `docs/advanced/no-go-install.md` and `docs/troubleshooting.md`, with cross-links from README, usage.md, and macos-startup.md.

## Test plan
- [x] `go test ./...` passes (new coverage: host-name handling, Docker build args, no-Go wrapper behavior)
- [x] `./start` on a machine with valid local Go
- [x] `./start` on a machine with no Go / broken Go install → containerized fallback runs
- [x] `start.ps1` / `start.cmd` on native Windows
- [x] `examples/macos/start-epar.command` still launches correctly