### PR TITLE
Prepare repository for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report reproducible behavior that differs from the documentation or expected result.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Do not include credentials, private keys, tokens, or other secrets. For a security vulnerability, use the private reporting path in docs/security.md instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and the expected result.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest safe configuration and commands needed to reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include EPAR version or commit, provider, host operating system, and Docker or WSL version when relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs
+      description: Include relevant logs after removing secrets and private infrastructure details.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an improvement to EPAR.
+title: "feature: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow or limitation you are trying to address.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Explain the change you would like to see and any alternatives you considered.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include relevant provider, operating-system, or GitHub Actions details.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What problem does this pull request solve, and what changed? -->
+
+## Validation
+
+<!-- List the commands, workflow runs, or manual checks you performed. -->
+
+## Checklist
+
+- [ ] I kept credentials, private keys, tokens, and machine-specific configuration out of this pull request.
+- [ ] I added or updated tests where behavior changed.
+- [ ] I updated relevant documentation.
+- [ ] I read and followed the contributing guide and code of conduct.

--- a/.github/workflows/core-runner-verification.yml
+++ b/.github/workflows/core-runner-verification.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/core-runner-verification.yml
+++ b/.github/workflows/core-runner-verification.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   controller:
     name: Core runner controller
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: epar-live-ci
     # Leaves time for a cold image build and bounded cleanup around the
@@ -83,6 +84,7 @@ jobs:
 
   canary-1:
     name: Core canary 1
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on:
       group: epar-ci-canary
       labels: epar-core-${{ github.run_id }}-${{ github.run_attempt }}
@@ -128,6 +130,7 @@ jobs:
   canary-2:
     name: Core canary 2
     needs: canary-1
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on:
       group: epar-ci-canary
       labels: epar-core-${{ github.run_id }}-${{ github.run_attempt }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+We are committed to a welcoming, respectful, and constructive community.
+
+## Expected Behavior
+
+- Be respectful and professional in issues, pull requests, discussions, and reviews.
+- Focus feedback on ideas and technical work rather than people.
+- Welcome good-faith questions and contributions from people with different backgrounds and experience levels.
+
+## Unacceptable Behavior
+
+Harassment, discrimination, personal attacks, threats, deliberate disruption, and sharing another person's private information without permission are not acceptable.
+
+## Reporting
+
+Report conduct concerns privately to a repository maintainer through GitHub. Do not open a public issue for a conduct report. Maintainers will review reports promptly and may remove content, limit participation, or take other action needed to protect the community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to EPAR
+
+Thanks for taking the time to contribute.
+
+## Before You Start
+
+- Use GitHub issues to discuss bugs, documentation gaps, and proposed changes before starting substantial work.
+- Do not report security vulnerabilities in public issues. Follow [Security](docs/security.md) instead.
+- EPAR runs GitHub Actions jobs on trusted infrastructure. Changes that affect runners, credentials, container privileges, workflow permissions, or cleanup boundaries need clear security reasoning and tests.
+
+## Development Workflow
+
+1. Fork the repository and create a focused branch from `develop`.
+2. Keep the change small and document any operational or security behavior that it changes.
+3. Run the relevant tests locally. The baseline Go test suite is `go test ./...`.
+4. Open a pull request targeting `develop` and complete the pull-request template.
+
+Fork pull requests run the safe hosted verification workflow. The live EPAR canary is reserved for branches in this repository because it uses a protected environment and disposable privileged containers.
+
+## Pull Request Expectations
+
+- Explain the problem, the approach, and how you tested it.
+- Add or update tests when behavior changes.
+- Keep credentials, private keys, tokens, and machine-specific configuration out of commits.
+- Update the relevant documentation when a user-visible or operational behavior changes.
+
+By contributing, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -161,5 +161,7 @@ GitHub also warns against using self-hosted runners with public repositories tha
 - [Windows Startup](docs/advanced/windows-startup.md): start EPAR after Windows login.
 - [macOS Startup](docs/advanced/macos-startup.md): start EPAR after macOS login.
 - [Running EPAR Without Installing Go](docs/advanced/no-go-install.md): run from source with no local Go install.
-- [Security](docs/security.md): trust boundaries and secret handling.
+- [Security](docs/security.md): trust boundaries, secret handling, and private vulnerability reporting.
+- [Contributing](CONTRIBUTING.md): how to propose and validate changes.
+- [Code of Conduct](CODE_OF_CONDUCT.md): community expectations and reporting concerns.
 - [Level 1 Core Runner Verification](docs/core-runner-verification.md): trusted live CI setup, canary behavior, and cleanup.

--- a/docs/core-runner-verification.md
+++ b/docs/core-runner-verification.md
@@ -67,7 +67,7 @@ Requiring an environment reviewer is possible, but every matching push and same-
 
 ## Trust Boundaries and Triggers
 
-The controller job is privileged and secret-bearing. It receives the GitHub App key and a workflow token with Actions write permission, and it can start privileged containers in its disposable GitHub-hosted VM. It runs only for trusted repository changes: pushes to `develop` or `main`, and pull requests whose source branch is in this repository. Fork pull requests skip all three core-verification jobs before they can receive environment secrets or run on the canary group.
+The controller job is privileged and secret-bearing. It receives the GitHub App key and a workflow token with Actions write permission, and it can start privileged containers in its disposable GitHub-hosted VM. It runs only for trusted repository changes: pushes to `develop` or `main`, and pull requests whose source branch is in this repository. Fork pull requests still trigger the workflow, but all three core-verification jobs skip before they can receive environment secrets or run on the canary group.
 
 The two canary jobs do not receive the GitHub App key. They receive only the
 minimum workflow permissions needed for checkout and artifact operations, and
@@ -76,7 +76,7 @@ container.
 
 The workflow runs on:
 
-- pull requests targeting `develop` or `main` when the source branch belongs to this repository
+- pull requests targeting `develop` or `main` (fork pull requests still trigger this workflow, but core-verification jobs run only when the source branch belongs to this repository)
 - pushes to `develop` or `main`
 - manual `workflow_dispatch` after the workflow is present on the repository's default branch
 

--- a/docs/core-runner-verification.md
+++ b/docs/core-runner-verification.md
@@ -50,9 +50,7 @@ cannot accept them.
 
 ### GitHub App and protected environment
 
-The GitHub App must be installed in the target organization and have
-organization self-hosted-runner read/write permission. Create a GitHub Actions
-environment named `epar-live-ci`, restrict it to trusted branches, and add:
+The GitHub App must be installed in the target organization and have organization self-hosted-runner read/write permission. Create a GitHub Actions environment named `epar-live-ci`, choose **Selected branches and tags**, allow `develop`, `main`, and `refs/pull/*/merge`, and add:
 
 | Kind | Name | Value |
 | --- | --- | --- |
@@ -65,17 +63,11 @@ not store it in repository variables, workflow YAML, a tracked config file, or
 an artifact. The workflow materializes it in a mode-restricted temporary file
 on the controller and removes that file during cleanup.
 
-For the initial feature-branch test, allow
-`feature/level-1-core-runner-verification`. Allow `develop` for the ongoing push
-trigger. Requiring an environment reviewer is possible, but every matching
-push will wait for that approval.
+Requiring an environment reviewer is possible, but every matching push and same-repository pull request will wait for that approval.
 
 ## Trust Boundaries and Triggers
 
-The controller job is privileged and secret-bearing. It receives the GitHub
-App key and a workflow token with Actions write permission, and it can start
-privileged containers in its disposable GitHub-hosted VM. It runs only for
-trusted repository changes and never for pull-request events.
+The controller job is privileged and secret-bearing. It receives the GitHub App key and a workflow token with Actions write permission, and it can start privileged containers in its disposable GitHub-hosted VM. It runs only for trusted repository changes: pushes to `develop` or `main`, and pull requests whose source branch is in this repository. Fork pull requests skip all three core-verification jobs before they can receive environment secrets or run on the canary group.
 
 The two canary jobs do not receive the GitHub App key. They receive only the
 minimum workflow permissions needed for checkout and artifact operations, and
@@ -84,15 +76,11 @@ container.
 
 The workflow runs on:
 
-- pushes to `feature/level-1-core-runner-verification` during initial rollout
-- pushes to `develop`
-- manual `workflow_dispatch` after the workflow is present on the repository's
-  default branch
+- pull requests targeting `develop` or `main` when the source branch belongs to this repository
+- pushes to `develop` or `main`
+- manual `workflow_dispatch` after the workflow is present on the repository's default branch
 
-It intentionally has no `pull_request` or `pull_request_target` trigger. Do not
-add one: code from an untrusted pull request must not reach the controller,
-environment secrets, or privileged Docker host. Remove the temporary feature
-branch trigger after the initial rollout is complete.
+The workflow does not use `pull_request_target`. Keep the same-repository job guard on every core-verification job so code from a forked pull request cannot reach the controller, environment secrets, or privileged Docker host.
 
 ## Expected Result and Cleanup
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,6 +4,14 @@ EPAR is intended for trusted jobs by default. It adds cleanup and isolation arou
 
 GitHub's self-hosted runner warning still applies: GitHub recommends using self-hosted runners only with private repositories because public repository forks can run code on the runner machine through pull request workflows. Read the official GitHub guidance before exposing any self-hosted runner to public or untrusted workflows: [Adding self-hosted runners](https://docs.github.com/actions/hosting-your-own-runners/adding-self-hosted-runners).
 
+## Reporting A Vulnerability
+
+Security fixes are applied to the latest released version and the current default branch.
+
+Do not disclose suspected vulnerabilities in a public issue, discussion, pull request, or commit. Use this repository's private vulnerability reporting flow: open the **Security** tab, select **Report a vulnerability**, and provide a clear description, affected versions, reproduction steps or a proof of concept, and the potential impact.
+
+If private reporting is unavailable, contact a repository maintainer privately through GitHub and include the same information. We will acknowledge the report, investigate it, and coordinate a fix and disclosure timeline with you.
+
 ## What EPAR Improves
 
 Disposable instances reduce host pollution, stale runner state, and accidental cross-job interference. After a job completes, EPAR retires the instance and creates a replacement. For Docker-DinD, job-created containers, networks, volumes, and inner image cache live inside the runner container's private Docker daemon and are removed with that runner instance.


### PR DESCRIPTION
## What changed

- Prevent the live EPAR canary jobs from running for pull requests originating from forks.
- Update runner verification documentation for same-repository and fork pull requests.
- Add contributor guidance, a code of conduct, and issue/PR templates.
- Expand the security guidance with a private reporting path.

## Why

These changes prepare the project for public contributions while preserving the live runner verification cycle for trusted, same-repository pull requests.

## Impact

External contributors receive clear participation and reporting guidance. Fork pull requests skip the privileged live canary jobs; same-repository pull requests continue to run them.

## Validation

- The live EPAR runner verification workflow passed on this branch after the environment policy was updated to allow pull-request merge refs.
- Reviewed the branch diff against `develop`.