### PR TITLE
Harden runner replacement during GitHub outages

### DIFF
--- a/cmd/ephemeral-action-runner/init.go
+++ b/cmd/ephemeral-action-runner/init.go
@@ -481,6 +481,10 @@ image:
 pool:
   instances: 1
   namePrefix: %s
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]
@@ -545,6 +549,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: %s
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/cmd/ephemeral-action-runner/init_test.go
+++ b/cmd/ephemeral-action-runner/init_test.go
@@ -64,6 +64,18 @@ func TestInitCreatesDefaultDockerDindConfig(t *testing.T) {
 	if got, want := cfg.Pool.NamePrefix, "build-box-01-a4f9c2"; got != want {
 		t.Fatalf("pool.namePrefix = %q, want %q", got, want)
 	}
+	if got, want := cfg.Pool.ReplacementRetryInitialSeconds, 15; got != want {
+		t.Fatalf("pool.replacementRetryInitialSeconds = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryMaxSeconds, 1800; got != want {
+		t.Fatalf("pool.replacementRetryMaxSeconds = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryMultiplier, 2.0; got != want {
+		t.Fatalf("pool.replacementRetryMultiplier = %v, want %v", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryJitterPercent, 20; got != want {
+		t.Fatalf("pool.replacementRetryJitterPercent = %d, want %d", got, want)
+	}
 	if got, want := cfg.Logging.Directory, "work/logs"; got != want {
 		t.Fatalf("logging.directory = %q, want %q", got, want)
 	}
@@ -73,6 +85,9 @@ func TestInitCreatesDefaultDockerDindConfig(t *testing.T) {
 	}
 	if !strings.Contains(string(configText), "logging:\n  directory: work/logs\n  managerSinks: [console]\n") {
 		t.Fatalf("generated config did not include logging schema:\n%s", configText)
+	}
+	if !strings.Contains(string(configText), "replacementRetryInitialSeconds: 15\n  replacementRetryMaxSeconds: 1800\n  replacementRetryMultiplier: 2\n  replacementRetryJitterPercent: 20\n") {
+		t.Fatalf("generated config did not include replacement retry settings:\n%s", configText)
 	}
 	if got := strings.Join(cfg.Runner.Labels, ","); !strings.Contains(got, "epar-docker-dind-catthehacker-ubuntu") {
 		t.Fatalf("runner labels = %q", got)

--- a/cmd/ephemeral-action-runner/logging_test.go
+++ b/cmd/ephemeral-action-runner/logging_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +46,9 @@ func TestLogsPathListAndPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	canonicalOldPath, err := filepath.EvalSymlinks(oldPath)
+	if runtime.GOOS == "windows" && errors.Is(err, fs.ErrPermission) {
+		canonicalOldPath, err = filepath.Abs(oldPath)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,6 +114,63 @@ func TestWriteLastErrorReportUsesConfiguredDirectoryAndFallback(t *testing.T) {
 	fallback := writeLastErrorReport([]string{"start", "--project-root", fallbackRoot, "--config", "missing.yml"}, errors.New("fallback failure"))
 	if fallback != filepath.Join(fallbackRoot, "work", "logs", "epar-last-error.log") {
 		t.Fatalf("fallback report path = %q", fallback)
+	}
+}
+
+func TestWriteLastErrorReportRedactsSecretsAndRestrictsExistingFile(t *testing.T) {
+	root := t.TempDir()
+	configPath := writeLoggingCommandConfig(t, root, "custom-logs")
+	logRoot := filepath.Join(root, "custom-logs")
+	if err := os.MkdirAll(logRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lastPath := filepath.Join(logRoot, "epar-last-error.log")
+	if err := os.WriteFile(lastPath, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const sentinel = "registration-token-sentinel"
+	path := writeLastErrorReport(
+		[]string{"start", "--project-root", root, "--config", configPath},
+		errors.New("docker exec -e RUNNER_TOKEN="+sentinel+" failed"),
+	)
+	if path != lastPath {
+		t.Fatalf("report path = %q, want %q", path, lastPath)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(content), sentinel) {
+		t.Fatalf("last error report exposed sentinel token: %s", content)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("last error report mode = %#o, want 0600", got)
+		}
+	}
+	archives, err := filepath.Glob(filepath.Join(logRoot, "errors", "epar-*-error.log"))
+	if err != nil || len(archives) != 1 {
+		t.Fatalf("error archives = %v, err = %v", archives, err)
+	}
+	archiveContent, err := os.ReadFile(archives[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(archiveContent), sentinel) {
+		t.Fatalf("archived error report exposed sentinel token: %s", archiveContent)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(archives[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("archived error report mode = %#o, want 0600", got)
+		}
 	}
 }
 

--- a/cmd/ephemeral-action-runner/main.go
+++ b/cmd/ephemeral-action-runner/main.go
@@ -52,21 +52,21 @@ func writeLastErrorReport(args []string, runErr error) string {
 		return ""
 	}
 	now := time.Now().UTC()
-	content := fmt.Sprintf(`EPAR failed
+	content := provider.RedactText(fmt.Sprintf(`EPAR failed
 time: %s
 workingDirectory: %s
 command: %q
 
 %s
 error: %v
-`, now.Format(time.RFC3339), cwd, os.Args, versionString(), runErr)
+`, now.Format(time.RFC3339), cwd, os.Args, versionString(), runErr))
 
 	lastPath := logging.LastErrorPath(logDir)
-	if err := os.WriteFile(lastPath, []byte(content), 0644); err != nil {
+	if err := logging.WritePrivateFileAtomic(lastPath, []byte(content)); err != nil {
 		return ""
 	}
 	stampedPath := logging.ErrorPath(logDir, now)
-	_ = os.WriteFile(stampedPath, []byte(content), 0644)
+	_ = logging.WritePrivateFileAtomic(stampedPath, []byte(content))
 	return lastPath
 }
 
@@ -232,6 +232,11 @@ func runImage(args []string) error {
 			return err
 		}
 		defer m.Close()
+		controllerLock, err := m.AcquirePoolControllerLock()
+		if err != nil {
+			return err
+		}
+		defer controllerLock.Close()
 		return m.UpdateUpstream(context.Background())
 	case "build":
 		fs := flag.NewFlagSet("image build", flag.ExitOnError)
@@ -248,13 +253,17 @@ func runImage(args []string) error {
 		}
 		defer m.Close()
 		ctx := interruptContext()
-		controllerLock, err := m.AcquireHostTrustControllerLock()
+		poolControllerLock, err := m.AcquirePoolControllerLock()
 		if err != nil {
 			return err
 		}
-		defer m.Close()
-		if controllerLock != nil {
-			defer controllerLock.Close()
+		defer poolControllerLock.Close()
+		hostTrustControllerLock, err := m.AcquireHostTrustControllerLock()
+		if err != nil {
+			return err
+		}
+		if hostTrustControllerLock != nil {
+			defer hostTrustControllerLock.Close()
 		}
 		if *update {
 			if err := m.UpdateUpstream(ctx); err != nil {
@@ -273,6 +282,11 @@ func runImage(args []string) error {
 			return err
 		}
 		defer m.Close()
+		controllerLock, err := m.AcquirePoolControllerLock()
+		if err != nil {
+			return err
+		}
+		defer controllerLock.Close()
 		return m.RefreshScripts(interruptContext())
 	default:
 		return fmt.Errorf("unknown image subcommand %q", args[0])

--- a/cmd/ephemeral-action-runner/start.go
+++ b/cmd/ephemeral-action-runner/start.go
@@ -23,6 +23,10 @@ type hostTrustLockingStarterManager interface {
 	AcquireHostTrustControllerLock() (io.Closer, error)
 }
 
+type poolLockingStarterManager interface {
+	AcquirePoolControllerLock() (io.Closer, error)
+}
+
 type startupTimingStarterManager interface {
 	StartStartupTiming() (string, error)
 	FinishStartupTiming(error)
@@ -127,6 +131,17 @@ func runStartWithOptions(opts startOptions) (err error) {
 			timingManager.FinishStartupTiming(err)
 		}()
 	}
+	poolLockHeld := false
+	if lockingManager, ok := manager.(poolLockingStarterManager); ok {
+		controllerLock, err := lockingManager.AcquirePoolControllerLock()
+		if err != nil {
+			return err
+		}
+		if controllerLock != nil {
+			defer controllerLock.Close()
+			poolLockHeld = true
+		}
+	}
 	hostTrustLockHeld := false
 	if lockingManager, ok := manager.(hostTrustLockingStarterManager); ok {
 		controllerLock, err := lockingManager.AcquireHostTrustControllerLock()
@@ -153,6 +168,7 @@ func runStartWithOptions(opts startOptions) (err error) {
 		KeepOnExit:        opts.KeepOnExit,
 		ReplaceCompleted:  opts.ReplaceCompleted,
 		MonitorInterval:   opts.MonitorInterval,
+		PoolLockHeld:      poolLockHeld,
 		HostTrustLockHeld: hostTrustLockHeld,
 	})
 	return err

--- a/configs/docker-dind.act.example.yml
+++ b/configs/docker-dind.act.example.yml
@@ -22,6 +22,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/docker-dind.core.example.yml
+++ b/configs/docker-dind.core.example.yml
@@ -22,6 +22,10 @@ image:
 pool:
   instances: 1
   namePrefix: epar-ci-core
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/docker-dind.example.yml
+++ b/configs/docker-dind.example.yml
@@ -22,6 +22,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/docker-dind.web-e2e.example.yml
+++ b/configs/docker-dind.web-e2e.example.yml
@@ -23,6 +23,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/tart.example.yml
+++ b/configs/tart.example.yml
@@ -18,6 +18,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/tart.web-e2e.example.yml
+++ b/configs/tart.web-e2e.example.yml
@@ -18,6 +18,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/wsl.example.yml
+++ b/configs/wsl.example.yml
@@ -20,6 +20,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/wsl.lean.example.yml
+++ b/configs/wsl.lean.example.yml
@@ -19,6 +19,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/configs/wsl.web-e2e.example.yml
+++ b/configs/wsl.web-e2e.example.yml
@@ -19,6 +19,10 @@ pool:
   instances: 1
   # Must be unique for this machine/config within the GitHub organization.
   namePrefix: CHANGE-ME-unique-machine-prefix
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
 logging:
   directory: work/logs
   managerSinks: [console]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ EPAR looks for config in this order:
 | `github` | GitHub App ID, organization, private key path, and optional GitHub API/web URLs. |
 | `provider` | How EPAR creates disposable runners: `docker-dind`, `wsl`, or `tart`. |
 | `image` | Source image/rootfs, output image, runner version, and optional install scripts. |
-| `pool` | Runner count and instance name prefix. |
+| `pool` | Runner count, instance name prefix, and replacement retry policy. |
 | `logging` | Manager and transcript sinks, formats, rotation, retention, and log directory. |
 | `runner` | GitHub Actions labels, runner group, default-label policy, and whether to add the host-machine label. |
 | `docker` | Optional Docker registry mirrors and Docker-DinD daemon proxy settings. |
@@ -43,6 +43,22 @@ pool:
 ```
 
 `pool.namePrefix` is both the prefix for generated GitHub runner names and the cleanup boundary for GitHub runner records. It must be 2-40 characters and should leave room for EPAR's generated `-YYYYMMDD-HHMMSS-###` suffix. Do not reuse the same prefix on different machines or for separate EPAR supervisors in the same organization. If two machines share a prefix, one machine's cleanup can delete the other machine's GitHub runner record, causing the other supervisor to report that the runner record is gone and replace a healthy runner.
+
+Configure replacement retry behavior after a transient GitHub or network outage:
+
+```yaml
+pool:
+  replacementRetryInitialSeconds: 15
+  replacementRetryMaxSeconds: 1800
+  replacementRetryMultiplier: 2
+  replacementRetryJitterPercent: 20
+```
+
+These values default to `15`, `1800`, `2`, and `20`, so existing configurations remain valid without changes. `replacementRetryInitialSeconds` must be positive, `replacementRetryMaxSeconds` must be at least the initial delay, `replacementRetryMultiplier` must be at least `1`, and `replacementRetryJitterPercent` must be from `0` through `100`.
+
+The supervisor backs off only replacement allocation after transient network errors and GitHub HTTP `429` or `5xx` responses. The nominal delay doubles from 15 seconds to a 30-minute cap with the configured jitter; a longer GitHub `Retry-After` response takes precedence. Authentication and deterministic configuration failures remain fail-fast after safe rollback. Initial `pool up` startup also remains fail-fast rather than entering an unattended retry loop.
+
+`pool.instances` is an absolute local physical-instance cap, not only an online-runner target. Provisioning, ready, draining, quarantined, and cleanup-pending instances all count toward it. Host-trust generation rotation does not receive surge capacity: an old busy runner keeps its slot until it exits or is safely removed.
 
 Add or change workflow labels:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -59,6 +59,12 @@ sequenceDiagram
 
 `pool up --instances 2` keeps two runners available in the foreground. Replacement names use `pool.namePrefix` plus a timestamp and sequence suffix, for example `epar-20260703-010530-003`.
 
+The supervisor tracks every prefix-owned local resource as provisioning, ready, draining, quarantined, or cleanup-pending. All five states count against `pool.instances`, which is an absolute physical-instance cap. A cleanup failure, unknown remote state, or busy runner therefore blocks allocation rather than allowing a capacity surge; host-trust rotation follows the same rule.
+
+Reconciliation runs at startup and before each replacement allocation. It adopts healthy exact-name local/GitHub pairs, deletes proven stopped or unregistered local resources, and deletes exact stale GitHub records when GitHub is reachable. A pre-listener provisioning failure is locally rolled back immediately and queued for later exact-name GitHub reconciliation because registration may have partially succeeded. After the listener starts, uncertain GitHub readiness becomes quarantine rather than deletion until the remote state can be resolved.
+
+Supervised replacement treats network errors and GitHub HTTP `429` or `5xx` responses as transient: allocation pauses behind the configured exponential retry policy while monitoring and cleanup continue. A fully online replacement or successful adoption resets the retry delay. Initial pool startup remains fail-fast after safe rollback, and authentication or deterministic configuration failures are terminal rather than retryable.
+
 ## Liveness Model
 
 The foreground supervisor checks each instance every 15 seconds by default. A runner is considered healthy when:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,6 +22,16 @@ When `docker.registryMirrors` is configured, EPAR writes `/etc/docker/daemon.jso
 
 `pool up` cleans up prefixed instances and GitHub runner records when it exits. Use `--keep-on-exit` only when intentionally debugging a live instance after the supervisor stops. While the supervisor is not running, EPAR cannot retire or replace completed runners.
 
+## Capacity, Reconciliation, and Outage Recovery
+
+`pool.instances` is a strict cap on prefix-owned local resources. EPAR counts provisioning, ready, draining, quarantined, and cleanup-pending instances, so a GitHub outage or a failed cleanup cannot create a replacement storm. Host-trust rotation has no temporary surge allowance; old busy-generation instances retain their slots until they finish or can be safely retired.
+
+Only one controller may mutate a given canonical config, provider, and `pool.namePrefix` at a time. If another EPAR controller holds that lock, stop or reconfigure the other controller instead of forcing concurrent starts; use a distinct unique prefix for intentionally independent pools.
+
+At startup and before allocating a replacement, EPAR reconciles the provider inventory with exact-name GitHub runner records. Healthy pairs are adopted, stopped or proven unregistered local resources are removed, and exact stale GitHub records are deleted when GitHub is reachable. When GitHub is unavailable, an ambiguous local instance is quarantined and continues to consume capacity instead of being deleted or replaced. If old resources already exceed the configured cap, the supervisor creates nothing until safe cleanup or normal draining restores capacity.
+
+For transient network failures and GitHub `429` or `5xx` responses during supervised replacement, EPAR pauses allocation and retries with exponential backoff. The default nominal delays are 15, 30, 60, 120, 240, 480, 960, and 1800 seconds, each with ±20% jitter; a longer `Retry-After` response wins. Monitoring and housekeeping continue during that pause, and a successful adoption or fully online replacement resets the delay. Startup remains fail-fast after compensating rollback, and invalid configuration or GitHub authentication failures do not retry indefinitely.
+
 ## Cleanup Safety
 
 Cleanup only touches local instances and GitHub runner records matching `pool.namePrefix`:
@@ -55,6 +65,8 @@ This section is a compact checklist. For symptom-first diagnostics with host/pro
 - If repeated jobs still pull slowly after configuring a registry mirror, verify the mirror is reachable from inside the runner instance and that it supports the requested registry, image platform, and authentication model. Docker daemon mirrors primarily target Docker Hub; other registry caches may require workflow image references to use the cache registry URL.
 - If a mirrored workflow only improves modestly, check where the time is going. Registry mirrors mainly reduce image pull time; container startup, Compose health checks, database initialization, volume sync, browser tests, private image authentication, and CPU-bound or emulated workloads can still dominate the total job time.
 - If GitHub registration fails, confirm the app has permission to manage organization self-hosted runners and that the private key path is readable by the host user.
+- If GitHub returns transient `500`, `502`, `503`, or `429` errors while the supervisor is replacing a runner, leave the supervisor running so it can retain the strict cap, reconcile exact runner names after recovery, and retry on its configured backoff. Do not manually start a second supervisor with the same `pool.namePrefix`.
+- If registration fails before the runner listener starts, EPAR rolls back the local candidate immediately and later reconciles a possible exact-name GitHub record. If the listener already started but GitHub readiness is uncertain, EPAR quarantines that candidate; inspect the instance transcript and wait for GitHub recovery before manually deleting it.
 - If stale runners remain, run `ephemeral-action-runner cleanup`.
 - If using Tart `softnet`, verify the host has the privileges Tart requires.
 - If default WSL image build fails before import, confirm Docker Desktop, Docker Engine, or another Docker daemon is reachable so EPAR can export `ghcr.io/catthehacker/ubuntu:full-latest` into a rootfs tar. For lean WSL configs, confirm the clean Ubuntu rootfs was exported from an Ubuntu 24.04 WSL distro.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -273,7 +273,9 @@ go run ./cmd/ephemeral-action-runner pool up --instances 2
 
 `start` is the recommended public command because it also checks the image before starting runners. `pool up` is the lower-level supervisor command for users who already prepared the image.
 
-`pool up` keeps the requested number of runners online. Each GitHub ephemeral runner exits after one job. EPAR then retires that instance and creates a fresh replacement.
+`pool up` keeps the requested number of runners online. Each GitHub ephemeral runner exits after one job. EPAR then retires that instance and creates a fresh replacement. The requested count is a strict physical local-instance cap: provisioning, ready, draining, quarantined, and cleanup-pending resources all consume a slot, including old runners during host-trust rotation.
+
+When GitHub registration or readiness has a transient network, `429`, or `5xx` failure during supervised replacement, EPAR pauses allocation and retries with the configured exponential backoff while continuing monitoring and cleanup. It does not create extra candidates while remote state is uncertain; see [Configuration](configuration.md#common-edits) and [Operations](operations.md#capacity-reconciliation-and-outage-recovery) for retry settings and recovery steps.
 
 Stop the supervisor with Ctrl-C. By default, EPAR cleans up active instances and matching GitHub runner records before it exits.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -59,8 +60,12 @@ const (
 )
 
 type PoolConfig struct {
-	Instances  int
-	NamePrefix string
+	Instances                      int
+	NamePrefix                     string
+	ReplacementRetryInitialSeconds int
+	ReplacementRetryMaxSeconds     int
+	ReplacementRetryMultiplier     float64
+	ReplacementRetryJitterPercent  int
 }
 
 type LoggingConfig struct {
@@ -140,8 +145,12 @@ func Default() Config {
 			},
 		},
 		Pool: PoolConfig{
-			Instances:  1,
-			NamePrefix: "epar",
+			Instances:                      1,
+			NamePrefix:                     "epar",
+			ReplacementRetryInitialSeconds: 15,
+			ReplacementRetryMaxSeconds:     1800,
+			ReplacementRetryMultiplier:     2,
+			ReplacementRetryJitterPercent:  20,
 		},
 		Logging: LoggingConfig{
 			Directory:                "work/logs",
@@ -345,6 +354,30 @@ func apply(cfg *Config, section, key, value string) error {
 			cfg.Pool.Instances = v
 		case "namePrefix", "vmPrefix":
 			cfg.Pool.NamePrefix = value
+		case "replacementRetryInitialSeconds":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid pool.replacementRetryInitialSeconds: %w", err)
+			}
+			cfg.Pool.ReplacementRetryInitialSeconds = v
+		case "replacementRetryMaxSeconds":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid pool.replacementRetryMaxSeconds: %w", err)
+			}
+			cfg.Pool.ReplacementRetryMaxSeconds = v
+		case "replacementRetryMultiplier":
+			v, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("invalid pool.replacementRetryMultiplier: %w", err)
+			}
+			cfg.Pool.ReplacementRetryMultiplier = v
+		case "replacementRetryJitterPercent":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid pool.replacementRetryJitterPercent: %w", err)
+			}
+			cfg.Pool.ReplacementRetryJitterPercent = v
 		case "logDir":
 			return fmt.Errorf("pool.logDir is deprecated; use logging.directory")
 		default:
@@ -814,6 +847,18 @@ func Validate(cfg Config) error {
 	}
 	if cfg.Pool.Instances < 1 {
 		return fmt.Errorf("pool.instances must be 1 or greater")
+	}
+	if cfg.Pool.ReplacementRetryInitialSeconds <= 0 {
+		return fmt.Errorf("pool.replacementRetryInitialSeconds must be greater than zero")
+	}
+	if cfg.Pool.ReplacementRetryMaxSeconds < cfg.Pool.ReplacementRetryInitialSeconds {
+		return fmt.Errorf("pool.replacementRetryMaxSeconds must be greater than or equal to pool.replacementRetryInitialSeconds")
+	}
+	if math.IsNaN(cfg.Pool.ReplacementRetryMultiplier) || math.IsInf(cfg.Pool.ReplacementRetryMultiplier, 0) || cfg.Pool.ReplacementRetryMultiplier < 1 {
+		return fmt.Errorf("pool.replacementRetryMultiplier must be 1 or greater")
+	}
+	if cfg.Pool.ReplacementRetryJitterPercent < 0 || cfg.Pool.ReplacementRetryJitterPercent > 100 {
+		return fmt.Errorf("pool.replacementRetryJitterPercent must be between 0 and 100")
 	}
 	if err := ValidatePrefix(cfg.Pool.NamePrefix); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -77,6 +78,18 @@ image:
 	}
 	if got, want := cfg.Pool.Instances, 3; got != want {
 		t.Fatalf("pool.instances = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryInitialSeconds, 15; got != want {
+		t.Fatalf("pool.replacementRetryInitialSeconds = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryMaxSeconds, 1800; got != want {
+		t.Fatalf("pool.replacementRetryMaxSeconds = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryMultiplier, 2.0; got != want {
+		t.Fatalf("pool.replacementRetryMultiplier = %v, want %v", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryJitterPercent, 20; got != want {
+		t.Fatalf("pool.replacementRetryJitterPercent = %d, want %d", got, want)
 	}
 	if got, want := len(cfg.Image.CustomInstallScripts), 2; got != want {
 		t.Fatalf("custom install scripts = %d, want %d", got, want)
@@ -896,6 +909,106 @@ func TestValidateRejectsInvalidPoolInstances(t *testing.T) {
 	cfg.Pool.Instances = 0
 	if err := Validate(cfg); err == nil {
 		t.Fatal("pool.instances=0 accepted")
+	}
+}
+
+func TestLoadPoolReplacementRetryConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(path, []byte(`
+pool:
+  replacementRetryInitialSeconds: 12
+  replacementRetryMaxSeconds: 720
+  replacementRetryMultiplier: 1.5
+  replacementRetryJitterPercent: 0
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.Pool.ReplacementRetryInitialSeconds, 12; got != want {
+		t.Fatalf("pool.replacementRetryInitialSeconds = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryMaxSeconds, 720; got != want {
+		t.Fatalf("pool.replacementRetryMaxSeconds = %d, want %d", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryMultiplier, 1.5; got != want {
+		t.Fatalf("pool.replacementRetryMultiplier = %v, want %v", got, want)
+	}
+	if got, want := cfg.Pool.ReplacementRetryJitterPercent, 0; got != want {
+		t.Fatalf("pool.replacementRetryJitterPercent = %d, want %d", got, want)
+	}
+	if err := Validate(cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateRejectsInvalidPoolReplacementRetryConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{
+			name:   "initial retry delay is not positive",
+			mutate: func(cfg *Config) { cfg.Pool.ReplacementRetryInitialSeconds = 0 },
+		},
+		{
+			name:   "maximum retry delay is below initial delay",
+			mutate: func(cfg *Config) { cfg.Pool.ReplacementRetryMaxSeconds = cfg.Pool.ReplacementRetryInitialSeconds - 1 },
+		},
+		{
+			name:   "retry multiplier is below one",
+			mutate: func(cfg *Config) { cfg.Pool.ReplacementRetryMultiplier = 0.5 },
+		},
+		{
+			name:   "retry multiplier is not finite",
+			mutate: func(cfg *Config) { cfg.Pool.ReplacementRetryMultiplier = math.NaN() },
+		},
+		{
+			name:   "retry jitter is below zero",
+			mutate: func(cfg *Config) { cfg.Pool.ReplacementRetryJitterPercent = -1 },
+		},
+		{
+			name:   "retry jitter exceeds one hundred percent",
+			mutate: func(cfg *Config) { cfg.Pool.ReplacementRetryJitterPercent = 101 },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := Default()
+			test.mutate(&cfg)
+			if err := Validate(cfg); err == nil {
+				t.Fatal("Validate accepted invalid replacement retry configuration")
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidPoolReplacementRetryValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "initial retry delay", key: "replacementRetryInitialSeconds", value: "invalid"},
+		{name: "maximum retry delay", key: "replacementRetryMaxSeconds", value: "invalid"},
+		{name: "retry multiplier", key: "replacementRetryMultiplier", value: "invalid"},
+		{name: "retry jitter", key: "replacementRetryJitterPercent", value: "invalid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yml")
+			content := "pool:\n  " + test.key + ": " + test.value + "\n"
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(path); err == nil {
+				t.Fatal("Load accepted invalid replacement retry value")
+			}
+		})
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -236,6 +236,7 @@ func (c *Client) request(ctx context.Context, method, path, auth string, body, o
 			Path:       path,
 			StatusCode: resp.StatusCode,
 			Body:       strings.TrimSpace(string(respBody)),
+			RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After"), time.Now()),
 		}
 	}
 	if out == nil || len(respBody) == 0 {
@@ -249,8 +250,27 @@ type HTTPError struct {
 	Path       string
 	StatusCode int
 	Body       string
+	RetryAfter time.Duration
 }
 
 func (e *HTTPError) Error() string {
 	return fmt.Sprintf("github %s %s returned %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+}
+
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := time.ParseDuration(value + "s"); err == nil {
+		if seconds > 0 {
+			return seconds
+		}
+		return 0
+	}
+	when, err := http.ParseTime(value)
+	if err != nil || !when.After(now) {
+		return 0
+	}
+	return when.Sub(now)
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -27,6 +27,26 @@ func TestJWTShape(t *testing.T) {
 	}
 }
 
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "seconds", value: "120", want: 2 * time.Minute},
+		{name: "http date", value: now.Add(3 * time.Minute).Format(http.TimeFormat), want: 3 * time.Minute},
+		{name: "past date", value: now.Add(-time.Minute).Format(http.TimeFormat), want: 0},
+		{name: "invalid", value: "later", want: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseRetryAfter(test.value, now); got != test.want {
+				t.Fatalf("parseRetryAfter(%q) = %s, want %s", test.value, got, test.want)
+			}
+		})
+	}
+}
+
 func TestListRunnersUsesInstallationToken(t *testing.T) {
 	keyPath := writeKey(t)
 	var sawRunnerList bool

--- a/internal/logging/private_file.go
+++ b/internal/logging/private_file.go
@@ -1,0 +1,42 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WritePrivateFileAtomic replaces path with content through a same-directory
+// temporary file and enforces owner-only permissions on the result.
+func WritePrivateFileAtomic(path string, content []byte) error {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create private temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("restrict private temporary file: %w", err)
+	}
+	if _, err := temporary.Write(content); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write private temporary file: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync private temporary file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close private temporary file: %w", err)
+	}
+	if err := replaceFile(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace private file: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("restrict private file: %w", err)
+	}
+	return nil
+}

--- a/internal/logging/replace_windows.go
+++ b/internal/logging/replace_windows.go
@@ -3,16 +3,33 @@
 package logging
 
 import (
-	"errors"
-	"os"
+	"syscall"
+	"unsafe"
 )
 
+const (
+	moveFileReplaceExisting = 0x00000001
+	moveFileWriteThrough    = 0x00000008
+)
+
+var moveFileEx = syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
+
 func replaceFile(source, destination string) error {
-	if err := os.Rename(source, destination); err == nil {
-		return nil
-	}
-	if err := os.Remove(destination); err != nil && !errors.Is(err, os.ErrNotExist) {
+	sourcePath, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
 		return err
 	}
-	return os.Rename(source, destination)
+	destinationPath, err := syscall.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	result, _, callErr := moveFileEx.Call(
+		uintptr(unsafe.Pointer(sourcePath)),
+		uintptr(unsafe.Pointer(destinationPath)),
+		moveFileReplaceExisting|moveFileWriteThrough,
+	)
+	if result == 0 {
+		return callErr
+	}
+	return nil
 }

--- a/internal/logging/replace_windows.go
+++ b/internal/logging/replace_windows.go
@@ -29,6 +29,9 @@ func replaceFile(source, destination string) error {
 		moveFileReplaceExisting|moveFileWriteThrough,
 	)
 	if result == 0 {
+		if errno, ok := callErr.(syscall.Errno); ok && errno == 0 {
+			return syscall.EINVAL
+		}
 		return callErr
 	}
 	return nil

--- a/internal/pool/controller_lock.go
+++ b/internal/pool/controller_lock.go
@@ -1,0 +1,47 @@
+package pool
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/solutionforest/ephemeral-action-runner/internal/hosttrust"
+)
+
+// AcquirePoolControllerLock excludes another mutating controller for the same
+// canonical configuration, provider, and pool prefix on this host.
+func (m *Manager) AcquirePoolControllerLock() (io.Closer, error) {
+	providerType := strings.TrimSpace(strings.ToLower(m.Config.Provider.Type))
+	namePrefix := strings.TrimSpace(strings.ToLower(m.Config.Pool.NamePrefix))
+	if providerType == "" || namePrefix == "" {
+		return nil, fmt.Errorf("acquire pool controller lock: provider.type and pool.namePrefix are required")
+	}
+	configPath := strings.TrimSpace(m.ConfigPath)
+	if configPath == "" {
+		configPath = filepath.Join(m.ProjectRoot, ".local", "config.yml")
+	}
+	canonicalConfig, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("acquire pool controller lock: resolve config path: %w", err)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(canonicalConfig); resolveErr == nil {
+		canonicalConfig = resolved
+	}
+	canonicalConfig = filepath.Clean(canonicalConfig)
+	if runtime.GOOS == "windows" {
+		canonicalConfig = strings.ToLower(canonicalConfig)
+	}
+	identity := canonicalConfig + "\x00" + providerType + "\x00" + namePrefix
+	sum := sha256.Sum256([]byte(identity))
+	syntheticPath := filepath.Join(os.TempDir(), "ephemeral-action-runner", "pool-controller", hex.EncodeToString(sum[:])+".identity")
+	lock, err := hosttrust.AcquireConfigLock(syntheticPath)
+	if err != nil {
+		return nil, fmt.Errorf("acquire pool controller lock for provider %q prefix %q: %w", providerType, namePrefix, err)
+	}
+	return lock, nil
+}

--- a/internal/pool/controller_lock_test.go
+++ b/internal/pool/controller_lock_test.go
@@ -1,0 +1,97 @@
+package pool
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/solutionforest/ephemeral-action-runner/internal/config"
+)
+
+func TestPoolControllerLockConflictsForSameProviderAndPrefix(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	manager := Manager{ConfigPath: "config.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-same"}}}
+	first, err := manager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	if second, err := manager.AcquirePoolControllerLock(); err == nil {
+		_ = second.Close()
+		t.Fatal("second controller acquired the same provider/prefix lock")
+	}
+}
+
+func TestVerifyRequiresPoolControllerLock(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	manager := Manager{ProjectRoot: t.TempDir(), ConfigPath: "verify.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind", SourceImage: "image"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-verify"}}, Provider: &fakeProvider{}}
+	held, err := manager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+	err = manager.Verify(context.Background(), VerifyOptions{Instances: 1})
+	if err == nil || !strings.Contains(err.Error(), "lock") {
+		t.Fatalf("Verify() error = %v, want controller lock conflict", err)
+	}
+}
+
+func TestCleanupRequiresPoolControllerLock(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	manager := Manager{ProjectRoot: t.TempDir(), ConfigPath: "cleanup.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-cleanup"}}, Provider: &fakeProvider{}}
+	held, err := manager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+	err = manager.Cleanup(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "lock") {
+		t.Fatalf("Cleanup() error = %v, want controller lock conflict", err)
+	}
+}
+
+func TestProvisionPoolRequiresPoolControllerLock(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	manager := Manager{ProjectRoot: t.TempDir(), ConfigPath: "provision.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind", SourceImage: "image"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-provision"}}, Provider: &fakeProvider{}}
+	held, err := manager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+	_, err = manager.ProvisionPool(context.Background(), 1, false)
+	if err == nil || !strings.Contains(err.Error(), "lock") {
+		t.Fatalf("ProvisionPool() error = %v, want controller lock conflict", err)
+	}
+}
+
+func TestPoolControllerLockIsIndependentAcrossPoolIdentity(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	firstManager := Manager{ConfigPath: "first.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-first"}}}
+	secondManager := Manager{ConfigPath: "second.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-second"}}}
+	first, err := firstManager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := secondManager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatalf("independent pool identity was blocked: %v", err)
+	}
+	defer second.Close()
+}
+
+func TestPoolControllerLockIncludesCanonicalConfigIdentity(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	firstManager := Manager{ConfigPath: "first.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-shared-prefix"}}}
+	secondManager := Manager{ConfigPath: "second.yml", Config: config.Config{Provider: config.ProviderConfig{Type: "docker-dind"}, Pool: config.PoolConfig{NamePrefix: "epar-lock-shared-prefix"}}}
+	first, err := firstManager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := secondManager.AcquirePoolControllerLock()
+	if err != nil {
+		t.Fatalf("distinct canonical config identity was blocked: %v", err)
+	}
+	defer second.Close()
+}

--- a/internal/pool/host_trust.go
+++ b/internal/pool/host_trust.go
@@ -331,6 +331,8 @@ func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[stri
 		}
 		if found && runner.Busy {
 			m.infof("[%s] draining busy runner on old host trust generation %s\n", name, instance.HostTrustGeneration)
+			instance.Phase = LifecycleDraining
+			active[name] = instance
 			continue
 		}
 		reason := fmt.Sprintf("host trust generation changed from %s to %s", instance.HostTrustGeneration, current.Generation)

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +39,8 @@ type Manager struct {
 	hostTrustResolver     func(context.Context) (hosttrust.Snapshot, error)
 	hostTrustImageEnsurer func(context.Context) error
 	hostTrustImageMu      sync.Mutex
+	now                   func() time.Time
+	randomFloat64         func() float64
 }
 
 type GitHubClient interface {
@@ -59,7 +67,18 @@ type RunOptions struct {
 	ReplaceCompleted  bool
 	MonitorInterval   time.Duration
 	HostTrustLockHeld bool
+	PoolLockHeld      bool
 }
+
+type LifecyclePhase string
+
+const (
+	LifecycleProvisioning   LifecyclePhase = "provisioning"
+	LifecycleReady          LifecyclePhase = "ready"
+	LifecycleDraining       LifecyclePhase = "draining"
+	LifecycleQuarantined    LifecyclePhase = "quarantined"
+	LifecycleCleanupPending LifecyclePhase = "cleanup-pending"
+)
 
 type ProvisionedInstance struct {
 	Name                string
@@ -68,10 +87,12 @@ type ProvisionedInstance struct {
 	GuestLogPath        string
 	RunnerID            int64
 	HostTrustGeneration string
+	Phase               LifecyclePhase
 }
 
 var runtimeValidationRetryDelay = 5 * time.Second
 var runnerReadinessHealthCheckInterval = 2 * time.Second
+var dependencyHTTPStatusPattern = regexp.MustCompile(`(?i)(?:status code does not indicate success|http response code)\s*:\s*([0-9]{3})`)
 
 const (
 	cleanupTimeout                    = 5 * time.Minute
@@ -80,6 +101,11 @@ const (
 )
 
 func (m *Manager) Verify(ctx context.Context, opts VerifyOptions) error {
+	poolLock, err := m.AcquirePoolControllerLock()
+	if err != nil {
+		return err
+	}
+	defer poolLock.Close()
 	controllerLock, err := m.acquireHostTrustControllerLock()
 	if err != nil {
 		return err
@@ -148,6 +174,13 @@ func (m *Manager) Verify(ctx context.Context, opts VerifyOptions) error {
 }
 
 func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
+	if !opts.PoolLockHeld {
+		controllerLock, err := m.AcquirePoolControllerLock()
+		if err != nil {
+			return err
+		}
+		defer controllerLock.Close()
+	}
 	if !opts.HostTrustLockHeld {
 		controllerLock, err := m.AcquireHostTrustControllerLock()
 		if err != nil {
@@ -161,7 +194,20 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 	if opts.MonitorInterval <= 0 {
 		opts.MonitorInterval = 15 * time.Second
 	}
-	active := make(map[string]ProvisionedInstance)
+	if ctx.Err() != nil {
+		if opts.KeepOnExit {
+			return nil
+		}
+		return m.cleanupWithFreshContext()
+	}
+	active, err := m.reconcilePhysicalPool(ctx, nil, opts.Register)
+	if err != nil {
+		return fmt.Errorf("initial pool reconciliation: %w", err)
+	}
+	active, err = m.reduceOverCapacity(ctx, active, opts.Instances, opts.Register)
+	if err != nil {
+		return fmt.Errorf("initial over-capacity reconciliation: %w", err)
+	}
 	sequence := 1
 	poolTrustGeneration := ""
 	cleanup := func() error {
@@ -172,14 +218,26 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 	}
 	leaseAdd, stopLeaseKeeper := m.startHostTrustLeaseKeeper(ctx)
 	for len(active) < opts.Instances {
-		vm, err := m.provisionOne(ctx, RunnerName(m.Config.Pool.NamePrefix, sequence, time.Now()), opts.Register, opts.Register && opts.ReplaceCompleted)
-		sequence++
+		active, err = m.reconcilePhysicalPool(ctx, active, opts.Register)
 		if err != nil {
 			stopLeaseKeeper()
-			_ = cleanup()
-			return err
+			return fmt.Errorf("initial pool reconciliation before allocation: %w", err)
 		}
-		active[vm.Name] = vm
+		if len(active) >= opts.Instances {
+			break
+		}
+		vm, err := m.provisionOne(ctx, RunnerName(m.Config.Pool.NamePrefix, sequence, time.Now()), opts.Register, opts.Register && opts.ReplaceCompleted)
+		sequence++
+		if isPhysicalPhase(vm.Phase) {
+			active[vm.Name] = vm
+		}
+		if err != nil {
+			stopLeaseKeeper()
+			if ctx.Err() != nil {
+				return cleanup()
+			}
+			return errors.Join(err, m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
+		}
 		leaseAdd(vm)
 		if vm.HostTrustGeneration != "" {
 			poolTrustGeneration = vm.HostTrustGeneration
@@ -215,11 +273,14 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 	nextRetention := time.Now().Add(time.Duration(m.Config.Logging.RetentionIntervalMinutes) * time.Minute)
 	nextHostTrustCollection := time.Time{}
 	var currentHostTrust hosttrust.Snapshot
+	retry := replacementRetryState{}
 	for {
 		select {
 		case <-ctx.Done():
 			return cleanup()
 		case <-ticker.C:
+			now := m.currentTime()
+			dependencyCooldown := retry.active(now)
 			if m.Config.Logging.RetentionEnabled && !time.Now().Before(nextRetention) {
 				m.pruneLogsBestEffort()
 				nextRetention = time.Now().Add(time.Duration(m.Config.Logging.RetentionIntervalMinutes) * time.Minute)
@@ -241,7 +302,9 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 							// Idle runners are removed now; busy runners keep running but
 							// receive a mismatching lease so no subsequent job can start.
 							currentHostTrust = current
-							trustRetired += m.reconcileHostTrustRunners(ctx, active, current)
+							if !dependencyCooldown {
+								trustRetired += m.reconcileHostTrustRunners(ctx, active, current)
+							}
 							m.infof("host trust generation changed (%s -> %s); building replacement image\n", emptyDash(poolTrustGeneration), current.Generation)
 							ready = false
 							for attempt := 1; attempt <= 3; attempt++ {
@@ -275,9 +338,17 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 						}
 					}
 				}
-				if currentHostTrust.Generation != "" {
+				if currentHostTrust.Generation != "" && !dependencyCooldown {
 					trustRetired += m.reconcileHostTrustRunners(ctx, active, currentHostTrust)
 				}
+			}
+			if dependencyCooldown {
+				var localErr error
+				active, localErr = m.reconcileLocalInventory(active)
+				if localErr != nil {
+					m.warnf("local pool housekeeping warning during replacement cooldown: %v\n", localErr)
+				}
+				continue
 			}
 			if opts.ReplaceCompleted && !time.Now().Before(nextLivenessCheck) {
 				nextLivenessCheck = time.Now().Add(opts.MonitorInterval)
@@ -298,16 +369,41 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 					delete(active, name)
 				}
 			}
+			var reconcileErr error
+			beforeReconcile := active
+			active, reconcileErr = m.reconcilePhysicalPool(ctx, active, opts.Register)
+			if reconcileErr != nil {
+				if ctx.Err() != nil {
+					return cleanup()
+				}
+				if !isTransientDependencyError(reconcileErr) {
+					return errors.Join(fmt.Errorf("pool reconciliation: %w", reconcileErr), m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
+				}
+				retry.schedule(m, now, reconcileErr)
+				m.warnf("pool reconciliation deferred during transient dependency failure; retrying after %s: %v\n", retry.remaining(now), reconcileErr)
+				continue
+			}
+			retry.resetAfterAdoption(beforeReconcile, active)
+			active, reconcileErr = m.reduceOverCapacity(ctx, active, opts.Instances, opts.Register)
+			if reconcileErr != nil {
+				if !isTransientDependencyError(reconcileErr) {
+					return errors.Join(fmt.Errorf("reduce over-capacity pool: %w", reconcileErr), m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
+				}
+				retry.schedule(m, now, reconcileErr)
+				continue
+			}
 			if m.hostTrustEnabled() && currentHostTrust.Generation != "" && currentHostTrust.Generation != poolTrustGeneration {
 				trustCapacityReady = false
 			}
 			replacementCapacity := len(active)
 			needsTrustCapacity := false
 			if m.hostTrustEnabled() && currentHostTrust.Generation != "" {
-				replacementCapacity = currentHostTrustCapacity(active, currentHostTrust.Generation)
-				needsTrustCapacity = replacementCapacity < opts.Instances
+				needsTrustCapacity = currentHostTrustCapacity(active, currentHostTrust.Generation) < opts.Instances
 			}
 			if !trustCapacityReady || (!opts.ReplaceCompleted && trustRetired == 0 && !needsTrustCapacity) {
+				continue
+			}
+			if retry.active(now) {
 				continue
 			}
 			for replacementCapacity < opts.Instances {
@@ -318,13 +414,37 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 				}
 				name := RunnerName(m.Config.Pool.NamePrefix, sequence, time.Now())
 				sequence++
+				active, err = m.reconcilePhysicalPool(ctx, active, opts.Register)
+				if err != nil {
+					if !isTransientDependencyError(err) {
+						return errors.Join(fmt.Errorf("pool reconciliation before replacement allocation: %w", err), m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
+					}
+					retry.schedule(m, m.currentTime(), err)
+					m.warnf("[%s] replacement deferred during transient reconciliation failure: %v\n", name, err)
+					break
+				}
+				replacementCapacity = len(active)
+				if replacementCapacity >= opts.Instances {
+					break
+				}
 				m.infof("[%s] creating replacement runner\n", name)
 				vm, err := m.provisionOne(ctx, name, opts.Register, true)
+				if isPhysicalPhase(vm.Phase) {
+					active[vm.Name] = vm
+				}
 				if err != nil {
+					if ctx.Err() != nil {
+						return cleanup()
+					}
 					m.warnf("[%s] replacement failed: %v\n", name, err)
+					if !isTransientDependencyError(err) {
+						return errors.Join(err, m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
+					}
+					retry.schedule(m, m.currentTime(), err)
 					break
 				}
 				active[vm.Name] = vm
+				retry.reset()
 				replacementCapacity++
 				if vm.HostTrustGeneration != "" {
 					poolTrustGeneration = vm.HostTrustGeneration
@@ -345,13 +465,401 @@ func currentHostTrustCapacity(active map[string]ProvisionedInstance, generation 
 	return capacity
 }
 
+func isPhysicalPhase(phase LifecyclePhase) bool {
+	return phase == LifecycleProvisioning || phase == LifecycleReady || phase == LifecycleDraining || phase == LifecycleQuarantined || phase == LifecycleCleanupPending
+}
+
+func adoptedReadyInstance(before, after map[string]ProvisionedInstance) bool {
+	for name, instance := range after {
+		previous, found := before[name]
+		if instance.Phase == LifecycleReady && (!found || previous.Phase != LifecycleReady) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) reconcilePhysicalPool(ctx context.Context, known map[string]ProvisionedInstance, register bool) (map[string]ProvisionedInstance, error) {
+	reconciled, err := m.reconcileLocalInventoryWithContext(ctx, known)
+	if err != nil {
+		return known, err
+	}
+	if !register {
+		for name, vm := range reconciled {
+			if vm.Phase != LifecycleCleanupPending {
+				vm.Phase = LifecycleReady
+				reconciled[name] = vm
+			}
+		}
+		return reconciled, nil
+	}
+	if m.GitHub == nil {
+		return reconciled, fmt.Errorf("github client is required for registered pool reconciliation")
+	}
+	remoteByName := make(map[string]gh.Runner)
+	runners, err := m.GitHub.ListRunners(ctx)
+	if err != nil {
+		for name, vm := range reconciled {
+			if vm.Phase != LifecycleCleanupPending {
+				vm.Phase = LifecycleQuarantined
+				reconciled[name] = vm
+			}
+		}
+		return reconciled, err
+	}
+	for _, runner := range runners {
+		if HasPrefix(runner.Name, m.Config.Pool.NamePrefix) {
+			remoteByName[runner.Name] = runner
+		}
+	}
+	for name, vm := range reconciled {
+		if vm.Phase == LifecycleCleanupPending {
+			continue
+		}
+		runner, found := remoteByName[name]
+		if !found && isPhysicalPhase(vm.Phase) {
+			var lookupErr error
+			runner, found, lookupErr = m.GitHub.RunnerByName(ctx, name)
+			if lookupErr != nil {
+				vm.Phase = LifecycleQuarantined
+				reconciled[name] = vm
+				return reconciled, lookupErr
+			}
+		}
+		if !found {
+			if err := m.deleteLocalInstance(context.Background(), vm); err != nil {
+				vm.Phase = LifecycleCleanupPending
+				reconciled[name] = vm
+				m.warnf("[%s] unregistered-instance cleanup pending: %v\n", name, err)
+			} else {
+				delete(reconciled, name)
+			}
+			continue
+		}
+		delete(remoteByName, name)
+		vm.RunnerID = runner.ID
+		if runner.Status == "online" {
+			vm.Phase = LifecycleReady
+			reconciled[name] = vm
+			continue
+		}
+		if runner.Busy {
+			vm.Phase = LifecycleQuarantined
+			reconciled[name] = vm
+			continue
+		}
+		if vm.Phase == LifecycleQuarantined {
+			if err := m.retireInstance(context.Background(), vm, "GitHub recovered but quarantined runner remained offline"); err != nil {
+				vm.Phase = LifecycleCleanupPending
+				reconciled[name] = vm
+				m.warnf("[%s] recovered-offline retirement pending: %v\n", name, err)
+			} else {
+				delete(reconciled, name)
+			}
+			continue
+		}
+		alive, _, processErr := m.runnerProcessAlive(ctx, vm)
+		if processErr == nil && alive {
+			vm.Phase = LifecycleQuarantined
+			reconciled[name] = vm
+			continue
+		}
+		if err := m.retireInstance(context.Background(), vm, "reconciliation found offline runner with inactive listener"); err != nil {
+			vm.Phase = LifecycleCleanupPending
+			reconciled[name] = vm
+			m.warnf("[%s] inactive-instance cleanup pending: %v\n", name, err)
+		} else {
+			delete(reconciled, name)
+		}
+	}
+	for _, runner := range remoteByName {
+		if err := m.deleteRemoteRunner(context.Background(), runner); err != nil {
+			return reconciled, err
+		}
+		m.infof("reconciliation: deleted stale GitHub runner %s id=%d\n", runner.Name, runner.ID)
+	}
+	return reconciled, nil
+}
+
+func (m *Manager) reduceOverCapacity(ctx context.Context, active map[string]ProvisionedInstance, target int, register bool) (map[string]ProvisionedInstance, error) {
+	if len(active) <= target || !register || m.GitHub == nil {
+		return active, nil
+	}
+	names := make([]string, 0, len(active))
+	for name := range active {
+		names = append(names, name)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(names)))
+	for _, name := range names {
+		if len(active) <= target {
+			break
+		}
+		vm := active[name]
+		if vm.Phase != LifecycleReady {
+			continue
+		}
+		runner, found, err := m.GitHub.RunnerByName(ctx, name)
+		if err != nil {
+			return active, err
+		}
+		if !found || runner.Busy {
+			continue
+		}
+		vm.RunnerID = runner.ID
+		if err := m.retireInstance(context.Background(), vm, "reconciling legacy physical inventory above pool.instances"); err != nil {
+			vm.Phase = LifecycleCleanupPending
+			active[name] = vm
+			continue
+		}
+		delete(active, name)
+	}
+	return active, nil
+}
+
+func (m *Manager) reconcileLocalInventory(known map[string]ProvisionedInstance) (map[string]ProvisionedInstance, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	return m.reconcileLocalInventoryWithContext(ctx, known)
+}
+
+func (m *Manager) reconcileLocalInventoryWithContext(ctx context.Context, known map[string]ProvisionedInstance) (map[string]ProvisionedInstance, error) {
+	locals, err := m.Provider.List(ctx)
+	if err != nil {
+		return known, err
+	}
+	reconciled := make(map[string]ProvisionedInstance)
+	for _, local := range locals {
+		if !HasPrefix(local.Name, m.Config.Pool.NamePrefix) {
+			continue
+		}
+		vm := m.reconciledInstance(known, local.Name)
+		if !localInstanceStopped(local.State) {
+			reconciled[local.Name] = vm
+			continue
+		}
+		if err := m.deleteLocalInstance(context.Background(), vm); err != nil {
+			vm.Phase = LifecycleCleanupPending
+			reconciled[local.Name] = vm
+			m.warnf("[%s] stopped-instance cleanup pending: %v\n", local.Name, err)
+		}
+	}
+	return reconciled, nil
+}
+
+func (m *Manager) reconciledInstance(known map[string]ProvisionedInstance, name string) ProvisionedInstance {
+	if vm, found := known[name]; found {
+		return vm
+	}
+	return ProvisionedInstance{
+		Name:         name,
+		LogPath:      m.instanceLogPath(name, "."+m.Config.Provider.Type+".log"),
+		GuestLogPath: m.instanceLogPath(name, ".guest.log"),
+		Phase:        LifecycleQuarantined,
+	}
+}
+
+func localInstanceStopped(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "stopped", "exited", "dead", "failed":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) deleteLocalInstance(ctx context.Context, vm ProvisionedInstance) error {
+	cleanupCtx, cancel := context.WithTimeout(ctx, cleanupTimeout)
+	defer cancel()
+	stopCtx, stopCancel := context.WithTimeout(cleanupCtx, 60*time.Second)
+	_ = m.Provider.Stop(stopCtx, vm.Name)
+	stopCancel()
+	deleteCtx, deleteCancel := context.WithTimeout(cleanupCtx, 60*time.Second)
+	err := m.Provider.Delete(deleteCtx, vm.Name)
+	deleteCancel()
+	if err != nil {
+		return err
+	}
+	if releaseErr := m.releaseInstanceTranscripts(vm); releaseErr != nil {
+		m.logger().Warn("instance transcript close failed after local deletion", "provider", m.Config.Provider.Type, "instance", vm.Name, "operation", "reconcile", "error", releaseErr)
+	}
+	return nil
+}
+
+func (m *Manager) deleteRemoteRunner(ctx context.Context, runner gh.Runner) error {
+	deleteCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	return m.GitHub.DeleteRunnerIfExists(deleteCtx, runner.ID)
+}
+
+type replacementRetryState struct {
+	attempt int
+	next    time.Time
+}
+
+func (s *replacementRetryState) active(now time.Time) bool {
+	return !s.next.IsZero() && now.Before(s.next)
+}
+
+func (s *replacementRetryState) remaining(now time.Time) time.Duration {
+	if !s.active(now) {
+		return 0
+	}
+	return s.next.Sub(now).Round(time.Second)
+}
+
+func (s *replacementRetryState) schedule(m *Manager, now time.Time, err error) {
+	initial, maximum, multiplier, jitter := m.replacementRetrySettings()
+	nominal := float64(initial) * math.Pow(multiplier, float64(s.attempt))
+	if nominal > float64(maximum) {
+		nominal = float64(maximum)
+	}
+	factor := 1.0
+	if jitter > 0 {
+		factor += ((m.randomValue() * 2) - 1) * jitter
+	}
+	delay := time.Duration(nominal * factor)
+	if delay < time.Second {
+		delay = time.Second
+	}
+	if delay > maximum {
+		delay = maximum
+	}
+	if retryAfter := retryAfterDuration(err); retryAfter > delay {
+		delay = retryAfter
+	}
+	s.attempt++
+	s.next = now.Add(delay)
+}
+
+func (s *replacementRetryState) reset() {
+	s.attempt = 0
+	s.next = time.Time{}
+}
+
+func (s *replacementRetryState) resetAfterAdoption(before, after map[string]ProvisionedInstance) {
+	if adoptedReadyInstance(before, after) {
+		s.reset()
+	}
+}
+
+func (m *Manager) replacementRetrySettings() (time.Duration, time.Duration, float64, float64) {
+	initialSeconds := m.Config.Pool.ReplacementRetryInitialSeconds
+	if initialSeconds <= 0 {
+		initialSeconds = 15
+	}
+	maximumSeconds := m.Config.Pool.ReplacementRetryMaxSeconds
+	if maximumSeconds <= 0 {
+		maximumSeconds = 1800
+	}
+	multiplier := m.Config.Pool.ReplacementRetryMultiplier
+	if multiplier < 1 {
+		multiplier = 2
+	}
+	jitterPercent := m.Config.Pool.ReplacementRetryJitterPercent
+	if jitterPercent < 0 {
+		jitterPercent = 0
+	}
+	return time.Duration(initialSeconds) * time.Second, time.Duration(maximumSeconds) * time.Second, multiplier, float64(jitterPercent) / 100
+}
+
+func (m *Manager) currentTime() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
+}
+
+func (m *Manager) randomValue() float64 {
+	if m.randomFloat64 != nil {
+		return m.randomFloat64()
+	}
+	return rand.Float64()
+}
+
+func retryAfterDuration(err error) time.Duration {
+	var httpErr *gh.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.RetryAfter
+	}
+	return 0
+}
+
+func isTransientDependencyError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var httpErr *gh.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == http.StatusTooManyRequests || httpErr.StatusCode >= http.StatusInternalServerError
+	}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) {
+		return true
+	}
+	text := strings.ToLower(err.Error())
+	for _, match := range dependencyHTTPStatusPattern.FindAllStringSubmatch(text, -1) {
+		statusCode, parseErr := strconv.Atoi(match[1])
+		if parseErr == nil && (statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError) {
+			return true
+		}
+	}
+	for _, marker := range []string{
+		"badgateway", "gatewaytimeout", "internalservererror", "serviceunavailable",
+		"bad gateway", "gateway timeout", "internal server error", "service unavailable",
+		"connection reset", "connection refused", "temporary failure",
+		"tls handshake timeout", "i/o timeout", "no such host",
+	} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Manager) cleanupWithFreshContext() error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer cancel()
-	return m.Cleanup(cleanupCtx)
+	return m.cleanupUnlocked(cleanupCtx)
+}
+
+func (m *Manager) cleanupAfterTerminalFailure(active map[string]ProvisionedInstance, keep bool) error {
+	if keep {
+		return nil
+	}
+	var firstErr error
+	for _, vm := range active {
+		var err error
+		switch vm.Phase {
+		case LifecycleReady:
+			err = m.retireInstance(context.Background(), vm, "controller stopped after terminal pool failure")
+		case LifecycleCleanupPending, LifecycleProvisioning:
+			err = m.deleteLocalInstance(context.Background(), vm)
+		case LifecycleDraining, LifecycleQuarantined:
+			// These instances may already be running a job. They stay counted and
+			// are reconciled by the next controller instead of being killed merely
+			// because GitHub readiness or status became uncertain.
+			continue
+		}
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (m *Manager) ProvisionPool(ctx context.Context, instances int, register bool) ([]ProvisionedInstance, error) {
+	poolLock, err := m.AcquirePoolControllerLock()
+	if err != nil {
+		return nil, err
+	}
+	defer poolLock.Close()
+	hostTrustLock, err := m.AcquireHostTrustControllerLock()
+	if err != nil {
+		return nil, err
+	}
+	if hostTrustLock != nil {
+		defer hostTrustLock.Close()
+	}
 	instances = m.requestedInstances(instances)
 	names := RunnerNames(m.Config.Pool.NamePrefix, instances, time.Now())
 	out := make([]ProvisionedInstance, 0, len(names))
@@ -376,6 +884,15 @@ func (m *Manager) requestedInstances(override int) int {
 }
 
 func (m *Manager) Cleanup(ctx context.Context) error {
+	poolLock, err := m.AcquirePoolControllerLock()
+	if err != nil {
+		return err
+	}
+	defer poolLock.Close()
+	return m.cleanupUnlocked(ctx)
+}
+
+func (m *Manager) cleanupUnlocked(ctx context.Context) error {
 	var firstErr error
 	vms, err := m.Provider.List(ctx)
 	if err != nil {
@@ -458,7 +975,7 @@ func (m *Manager) provisionOne(ctx context.Context, name string, register, allow
 			return vm, err
 		}
 		lastErr = err
-		if vm.Name != "" {
+		if isPhysicalPhase(vm.Phase) {
 			_ = m.retireInstance(context.Background(), vm, "discarding stale host-trust image generation")
 		}
 		if attempt == attempts {
@@ -472,10 +989,56 @@ func (m *Manager) provisionOne(ctx context.Context, name string, register, allow
 	return ProvisionedInstance{Name: name}, fmt.Errorf("provision runner after %d host trust image stabilization attempts: %w", attempts, lastErr)
 }
 
-func (m *Manager) provisionOneAttempt(ctx context.Context, name string, register, allowBusy bool) (ProvisionedInstance, error) {
+func (m *Manager) deleteRemoteRunnerByNameBestEffort(name string) {
+	if m.GitHub == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	runner, found, err := m.GitHub.RunnerByName(ctx, name)
+	if err != nil {
+		m.warnf("[%s] deferred exact-name GitHub reconciliation after rollback: %v\n", name, err)
+		return
+	}
+	if !found {
+		return
+	}
+	if err := m.GitHub.DeleteRunnerIfExists(ctx, runner.ID); err != nil {
+		m.warnf("[%s] deferred exact-name GitHub runner deletion after rollback: %v\n", name, err)
+	}
+}
+
+func (m *Manager) provisionOneAttempt(ctx context.Context, name string, register, allowBusy bool) (vm ProvisionedInstance, err error) {
 	logPath := m.instanceLogPath(name, "."+m.Config.Provider.Type+".log")
 	guestLogPath := m.instanceLogPath(name, ".guest.log")
-	vm := ProvisionedInstance{Name: name, LogPath: logPath, GuestLogPath: guestLogPath}
+	vm = ProvisionedInstance{Name: name, LogPath: logPath, GuestLogPath: guestLogPath, Phase: LifecycleProvisioning}
+	localMayExist := false
+	configureAttempted := false
+	listenerMayBeRunning := false
+	defer func() {
+		if err == nil {
+			vm.Phase = LifecycleReady
+			return
+		}
+		if !localMayExist {
+			vm.Phase = ""
+			return
+		}
+		if listenerMayBeRunning {
+			vm.Phase = LifecycleQuarantined
+			return
+		}
+		cleanupErr := m.deleteLocalInstance(context.Background(), vm)
+		if cleanupErr != nil {
+			vm.Phase = LifecycleCleanupPending
+			err = errors.Join(err, fmt.Errorf("rollback local instance %s: %w", name, cleanupErr))
+			return
+		}
+		vm.Phase = ""
+		if configureAttempted {
+			m.deleteRemoteRunnerByNameBestEffort(name)
+		}
+	}()
 	var trustSnapshot hosttrust.Snapshot
 	if m.hostTrustEnabled() {
 		var err error
@@ -489,6 +1052,7 @@ func (m *Manager) provisionOneAttempt(ctx context.Context, name string, register
 		return vm, err
 	}
 	m.logger().Info("cloning instance", "provider", m.Config.Provider.Type, "instance", name, "operation", "clone", "sourceImage", m.Config.Provider.SourceImage, "logPath", logPath)
+	localMayExist = true
 	if err := m.timeFirstInstanceStage(name, "instance_container_create", func() error {
 		return m.Provider.Clone(ctx, m.Config.Provider.SourceImage, name)
 	}); err != nil {
@@ -564,17 +1128,18 @@ func (m *Manager) provisionOneAttempt(ctx context.Context, name string, register
 			}
 			env := map[string]string{
 				"RUNNER_URL":               m.GitHub.OrganizationURL(),
-				"RUNNER_TOKEN":             token.Token,
 				"RUNNER_NAME":              name,
 				"RUNNER_LABELS":            strings.Join(m.Config.Runner.Labels, ","),
 				"RUNNER_EPHEMERAL":         fmt.Sprintf("%t", m.Config.Runner.Ephemeral),
 				"RUNNER_GROUP":             m.Config.Runner.Group,
 				"RUNNER_NO_DEFAULT_LABELS": fmt.Sprintf("%t", m.Config.Runner.NoDefaultLabels),
 			}
-			if _, err := m.execGuest(ctx, name, []string{"sudo", "-E", "bash", "/opt/epar/configure-runner.sh"}, provider.ExecOptions{Env: env}); err != nil {
-				return err
+			configureAttempted = true
+			if _, err := m.execGuest(ctx, name, []string{"sudo", "-E", "bash", "/opt/epar/configure-runner.sh"}, provider.ExecOptions{Env: env, Stdin: token.Token + "\n", SensitiveValues: []string{token.Token}}); err != nil {
+				return provider.RedactError(err, token.Token)
 			}
 			m.infof("[%s] starting runner service\n", name)
+			listenerMayBeRunning = true
 			if _, err := m.execGuest(ctx, name, []string{"sudo", "bash", "/opt/epar/run-runner.sh"}, provider.ExecOptions{}); err != nil {
 				return err
 			}

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -261,6 +263,7 @@ func TestRunPoolDoesNotReplaceWhenRetirementIsDeferred(t *testing.T) {
 		KeepOnExit:       true,
 		ReplaceCompleted: true,
 		MonitorInterval:  5 * time.Millisecond,
+		PoolLockHeld:     true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -294,6 +297,7 @@ func TestRunPoolReplacesCompletedRunnerAfterBusyProvisioning(t *testing.T) {
 		KeepOnExit:       true,
 		ReplaceCompleted: true,
 		MonitorInterval:  5 * time.Millisecond,
+		PoolLockHeld:     true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -366,12 +370,12 @@ func TestRunPoolAddsCurrentTrustCapacityWhileOldGenerationDrains(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
 	defer cancel()
 	if err := manager.RunPool(ctx, RunOptions{
-		Instances: 1, Register: true, KeepOnExit: true, ReplaceCompleted: false, MonitorInterval: 5 * time.Millisecond, HostTrustLockHeld: true,
+		Instances: 1, Register: true, KeepOnExit: true, ReplaceCompleted: false, MonitorInterval: 5 * time.Millisecond, HostTrustLockHeld: true, PoolLockHeld: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if got := atomic.LoadInt32(&fake.cloneCalls); got < 2 {
-		t.Fatalf("Clone called %d time(s), want G2 replacement while busy G1 drains", got)
+	if got := atomic.LoadInt32(&fake.cloneCalls); got != 1 {
+		t.Fatalf("Clone called %d time(s), want strict physical cap while busy G1 drains", got)
 	}
 	if got := atomic.LoadInt32(&fake.deleteCalls); got != 0 {
 		t.Fatalf("busy G1 was deleted %d time(s), want it left draining", got)
@@ -382,13 +386,14 @@ func TestRunPoolAddsCurrentTrustCapacityWhileOldGenerationDrains(t *testing.T) {
 }
 
 func TestVerifyUsesIdleReadiness(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
 	provider := &fakeProvider{ip: "127.0.0.1"}
 	github := &fakeGitHub{
 		waitRunner: gh.Runner{Name: "epar-test-1", ID: 123, Status: "online"},
 	}
 	manager := Manager{
 		Config: config.Config{
-			Provider: config.ProviderConfig{SourceImage: "image"},
+			Provider: config.ProviderConfig{SourceImage: "image", Type: "docker-dind"},
 			Pool:     config.PoolConfig{Instances: 1, NamePrefix: "epar-test"},
 			Logging:  config.LoggingConfig{Directory: t.TempDir()},
 			Runner:   config.RunnerConfig{Labels: []string{"self-hosted"}, Ephemeral: true},
@@ -428,6 +433,7 @@ func TestRunPoolUsesConfiguredInstancesWhenNoOverride(t *testing.T) {
 		Register:         false,
 		KeepOnExit:       true,
 		ReplaceCompleted: false,
+		PoolLockHeld:     true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -465,6 +471,7 @@ func TestProvisionOneRetriesTransientRuntimeValidationFailure(t *testing.T) {
 }
 
 func TestVerifyCleanupUsesFreshContextAfterCancellation(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", t.TempDir())
 	provider := &fakeProvider{
 		instances: []provider.Instance{
 			{Name: "epar-test-1"},
@@ -491,11 +498,11 @@ func TestVerifyCleanupUsesFreshContextAfterCancellation(t *testing.T) {
 	if got := atomic.LoadInt32(&provider.canceledListCalls); got != 0 {
 		t.Fatalf("cleanup List received a canceled context %d time(s)", got)
 	}
-	if got := atomic.LoadInt32(&provider.stopCalls); got != 2 {
-		t.Fatalf("Stop called %d time(s), want 2 matching prefix-boundary instances", got)
+	if got := atomic.LoadInt32(&provider.stopCalls); got != 3 {
+		t.Fatalf("Stop called %d time(s), want 3 matching prefix-boundary instances including the verified candidate", got)
 	}
-	if got := atomic.LoadInt32(&provider.deleteCalls); got != 2 {
-		t.Fatalf("Delete called %d time(s), want 2 matching prefix-boundary instances", got)
+	if got := atomic.LoadInt32(&provider.deleteCalls); got != 3 {
+		t.Fatalf("Delete called %d time(s), want 3 matching prefix-boundary instances including the verified candidate", got)
 	}
 }
 
@@ -516,7 +523,7 @@ func TestRunPoolCleanupUsesFreshContextAfterCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := manager.RunPool(ctx, RunOptions{Instances: 1}); err != nil {
+	if err := manager.RunPool(ctx, RunOptions{Instances: 1, PoolLockHeld: true}); err != nil {
 		t.Fatal(err)
 	}
 	if got := atomic.LoadInt32(&provider.canceledListCalls); got != 0 {
@@ -577,11 +584,19 @@ func TestProvisionOnePassesRunnerRegistrationControlsWithoutPrivateKey(t *testin
 		"RUNNER_NO_DEFAULT_LABELS": "true",
 		"RUNNER_LABELS":            "epar-core-test",
 		"RUNNER_EPHEMERAL":         "true",
-		"RUNNER_TOKEN":             "token",
 	} {
 		if got := env[key]; got != want {
 			t.Errorf("%s = %q, want %q", key, got, want)
 		}
+	}
+	provider.mu.Lock()
+	configureOptions := provider.configureOptions
+	provider.mu.Unlock()
+	if configureOptions.Stdin != "token\n" {
+		t.Fatalf("configure stdin = %q, want registration token line", configureOptions.Stdin)
+	}
+	if len(configureOptions.SensitiveValues) != 1 || configureOptions.SensitiveValues[0] != "token" {
+		t.Fatalf("configure sensitive values = %#v, want registration token", configureOptions.SensitiveValues)
 	}
 	for key, value := range env {
 		if strings.Contains(strings.ToLower(key), "private") || value == "/secret/app.pem" {
@@ -731,6 +746,440 @@ func TestProvisionOneReadinessSucceedsWhileRunnerProcessStaysHealthy(t *testing.
 	}
 }
 
+func TestProvisioningFailureRollbackBoundary(t *testing.T) {
+	tests := []struct {
+		name            string
+		configure       func(*fakeProvider, *fakeGitHub)
+		wantPhase       LifecyclePhase
+		wantLocalDelete bool
+	}{
+		{name: "partial clone", configure: func(p *fakeProvider, _ *fakeGitHub) { p.cloneErr = errors.New("clone failed after partial creation") }, wantLocalDelete: true},
+		{name: "start", configure: func(p *fakeProvider, _ *fakeGitHub) { p.startErr = errors.New("start failed") }, wantLocalDelete: true},
+		{name: "ip", configure: func(p *fakeProvider, _ *fakeGitHub) { p.ipErr = errors.New("ip failed") }, wantLocalDelete: true},
+		{name: "runtime", configure: func(p *fakeProvider, _ *fakeGitHub) { p.execErr = errors.New("runtime validation failed") }, wantLocalDelete: true},
+		{name: "token", configure: func(_ *fakeProvider, g *fakeGitHub) { g.registrationErr = errors.New("token failed") }, wantLocalDelete: true},
+		{name: "configure runner", configure: func(p *fakeProvider, _ *fakeGitHub) {
+			p.execFunc = func(_ context.Context, _ string, command []string, _ provider.ExecOptions) (provider.ExecResult, error) {
+				if strings.Contains(strings.Join(command, " "), "configure-runner.sh") {
+					return provider.ExecResult{}, errors.New("Http response code: ServiceUnavailable (503)")
+				}
+				return provider.ExecResult{}, nil
+			}
+		}, wantLocalDelete: true},
+		{name: "listener start uncertain", configure: func(p *fakeProvider, _ *fakeGitHub) {
+			p.execFunc = func(_ context.Context, _ string, command []string, _ provider.ExecOptions) (provider.ExecResult, error) {
+				if strings.Contains(strings.Join(command, " "), "run-runner.sh") {
+					return provider.ExecResult{}, errors.New("listener start failed ambiguously")
+				}
+				return provider.ExecResult{}, nil
+			}
+		}, wantPhase: LifecycleQuarantined},
+		{name: "readiness", configure: func(_ *fakeProvider, g *fakeGitHub) { g.waitErr = errors.New("GitHub readiness failed") }, wantPhase: LifecycleQuarantined},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &fakeProvider{ip: "127.0.0.1"}
+			g := &fakeGitHub{}
+			tt.configure(p, g)
+			manager := newRegisteredTestManager(t, p, g)
+			vm, err := manager.provisionOne(context.Background(), "epar-test-stage", true, false)
+			if err == nil {
+				t.Fatal("provisionOne() error = nil")
+			}
+			if vm.Phase != tt.wantPhase {
+				t.Fatalf("phase = %q, want %q", vm.Phase, tt.wantPhase)
+			}
+			if tt.wantLocalDelete && atomic.LoadInt32(&p.deleteCalls) == 0 {
+				t.Fatal("pre-listener failure did not roll back local candidate")
+			}
+			if !tt.wantLocalDelete && atomic.LoadInt32(&p.deleteCalls) != 0 {
+				t.Fatal("post-listener uncertainty deleted local candidate")
+			}
+		})
+	}
+}
+
+func TestConfigureFailureDeletesExactLocalAndRemoteCandidate(t *testing.T) {
+	p := &fakeProvider{ip: "127.0.0.1"}
+	p.execFunc = func(_ context.Context, _ string, command []string, _ provider.ExecOptions) (provider.ExecResult, error) {
+		if strings.Contains(strings.Join(command, " "), "configure-runner.sh") {
+			return provider.ExecResult{}, errors.New("Http response code: BadGateway from runner-registration (502)")
+		}
+		return provider.ExecResult{}, nil
+	}
+	g := &fakeGitHub{runner: gh.Runner{Name: "epar-test-candidate", ID: 456}, found: true}
+	manager := newRegisteredTestManager(t, p, g)
+	vm, err := manager.provisionOne(context.Background(), "epar-test-candidate", true, false)
+	if err == nil {
+		t.Fatal("provisionOne() error = nil")
+	}
+	if vm.Phase != "" {
+		t.Fatalf("phase = %q, want no surviving physical candidate", vm.Phase)
+	}
+	if got := atomic.LoadInt32(&p.deleteCalls); got != 1 {
+		t.Fatalf("local delete calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&g.deleteCalls); got != 1 {
+		t.Fatalf("remote delete calls = %d, want 1", got)
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.deletedIDs) != 1 || g.deletedIDs[0] != 456 {
+		t.Fatalf("deleted remote IDs = %v, want [456]", g.deletedIDs)
+	}
+}
+
+func TestConfigureFailureRedactsRegistrationTokenFromErrorAndTiming(t *testing.T) {
+	const sentinel = "SENTINEL-RUNNER-REGISTRATION-TOKEN"
+	p := &fakeProvider{ip: "127.0.0.1"}
+	p.execFunc = func(_ context.Context, _ string, command []string, _ provider.ExecOptions) (provider.ExecResult, error) {
+		if strings.Contains(strings.Join(command, " "), "configure-runner.sh") {
+			return provider.ExecResult{}, fmt.Errorf("configure failed with token %s", sentinel)
+		}
+		return provider.ExecResult{}, nil
+	}
+	g := &fakeGitHub{registrationToken: sentinel}
+	manager := newRegisteredTestManager(t, p, g)
+	timingPath, err := manager.StartStartupTiming()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, provisionErr := manager.provisionOne(context.Background(), "epar-test-secret", true, false)
+	if provisionErr == nil {
+		t.Fatal("provisionOne() error = nil")
+	}
+	manager.FinishStartupTiming(provisionErr)
+	if strings.Contains(provisionErr.Error(), sentinel) {
+		t.Fatalf("returned error leaked registration token: %v", provisionErr)
+	}
+	content, err := os.ReadFile(timingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(content), sentinel) {
+		t.Fatalf("startup timing leaked registration token: %s", content)
+	}
+}
+
+func TestOneHundredRegistrationOutagesNeverExceedPhysicalCap(t *testing.T) {
+	p := &fakeProvider{ip: "127.0.0.1"}
+	p.execFunc = func(_ context.Context, _ string, command []string, _ provider.ExecOptions) (provider.ExecResult, error) {
+		if strings.Contains(strings.Join(command, " "), "configure-runner.sh") {
+			return provider.ExecResult{}, errors.New("Http response code: ServiceUnavailable (503)")
+		}
+		return provider.ExecResult{}, nil
+	}
+	manager := newRegisteredTestManager(t, p, &fakeGitHub{})
+	manager.Config.Pool.Instances = 2
+	for i := 0; i < 100; i++ {
+		name := fmt.Sprintf("epar-test-outage-%03d", i)
+		if _, err := manager.provisionOne(context.Background(), name, true, true); err == nil {
+			t.Fatalf("cycle %d unexpectedly succeeded", i)
+		}
+	}
+	if got := atomic.LoadInt32(&p.maxInventory); got > 2 {
+		t.Fatalf("maximum physical inventory = %d, want <= 2", got)
+	}
+	instances, err := p.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 0 {
+		t.Fatalf("surviving physical inventory = %d, want 0 after local rollback", len(instances))
+	}
+}
+
+func TestCleanupFailureRemainsCountedAndBlocksClone(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-existing", State: "running"}}, deleteErr: errors.New("delete failed")}
+	g := &fakeGitHub{}
+	manager := newRegisteredTestManager(t, p, g)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := manager.RunPool(ctx, RunOptions{Instances: 1, Register: true, KeepOnExit: true, ReplaceCompleted: true, MonitorInterval: time.Millisecond, PoolLockHeld: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&p.cloneCalls); got != 0 {
+		t.Fatalf("clone calls = %d, want 0 while cleanup-pending resource occupies capacity", got)
+	}
+}
+
+func TestInitialTerminalFailureCleansReadyInstancesButPreservesQuarantine(t *testing.T) {
+	t.Run("pre-listener failure cleans earlier ready capacity", func(t *testing.T) {
+		var configureCalls int32
+		p := &fakeProvider{ip: "127.0.0.1"}
+		p.execFunc = func(_ context.Context, _ string, command []string, _ provider.ExecOptions) (provider.ExecResult, error) {
+			if strings.Contains(strings.Join(command, " "), "configure-runner.sh") && atomic.AddInt32(&configureCalls, 1) == 2 {
+				return provider.ExecResult{}, errors.New("Response status code does not indicate success: 401")
+			}
+			return provider.ExecResult{}, nil
+		}
+		g := &fakeGitHub{runner: gh.Runner{ID: 123, Status: "online"}, found: true, waitRunner: gh.Runner{ID: 123, Status: "online"}}
+		manager := newRegisteredTestManager(t, p, g)
+		err := manager.RunPool(context.Background(), RunOptions{Instances: 2, Register: true, ReplaceCompleted: true, PoolLockHeld: true})
+		if err == nil {
+			t.Fatal("RunPool() error = nil")
+		}
+		if got := atomic.LoadInt32(&p.deleteCalls); got < 2 {
+			t.Fatalf("local delete calls = %d, want failed candidate rollback plus ready-instance terminal cleanup", got)
+		}
+	})
+
+	t.Run("post-listener uncertainty survives terminal return", func(t *testing.T) {
+		p := &fakeProvider{ip: "127.0.0.1"}
+		g := &fakeGitHub{waitErr: errors.New("Response status code does not indicate success: 401")}
+		manager := newRegisteredTestManager(t, p, g)
+		err := manager.RunPool(context.Background(), RunOptions{Instances: 1, Register: true, ReplaceCompleted: true, PoolLockHeld: true})
+		if err == nil {
+			t.Fatal("RunPool() error = nil")
+		}
+		if got := atomic.LoadInt32(&p.deleteCalls); got != 0 {
+			t.Fatalf("local delete calls = %d, want quarantined post-listener candidate preserved", got)
+		}
+	})
+}
+
+func TestShutdownCancellationPreservesPostListenerCandidateWhenKeepOnExit(t *testing.T) {
+	p := &fakeProvider{ip: "127.0.0.1"}
+	g := &fakeGitHub{waitFunc: func(ctx context.Context, _ string, _ time.Duration) (gh.Runner, error) {
+		<-ctx.Done()
+		return gh.Runner{}, ctx.Err()
+	}}
+	manager := newRegisteredTestManager(t, p, g)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := manager.RunPool(ctx, RunOptions{Instances: 1, Register: true, KeepOnExit: true, ReplaceCompleted: true, PoolLockHeld: true}); err != nil {
+		t.Fatalf("RunPool() cancellation error = %v, want clean shutdown", err)
+	}
+	if got := atomic.LoadInt32(&p.deleteCalls); got != 0 {
+		t.Fatalf("local delete calls = %d, want post-listener candidate preserved by keep-on-exit", got)
+	}
+	instances, err := p.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("surviving local instances = %d, want 1 quarantined candidate", len(instances))
+	}
+}
+
+func TestStoppedLocalIsCleanedEvenWhenGitHubIsUnavailable(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-stopped", State: "stopped"}}}
+	g := &fakeGitHub{listErr: &gh.HTTPError{StatusCode: 503}}
+	manager := newRegisteredTestManager(t, p, g)
+	active, err := manager.reconcilePhysicalPool(context.Background(), nil, true)
+	if err == nil {
+		t.Fatal("reconcilePhysicalPool() error = nil, want GitHub outage")
+	}
+	if len(active) != 0 {
+		t.Fatalf("active = %#v, want stopped local removed", active)
+	}
+	if got := atomic.LoadInt32(&p.deleteCalls); got != 1 {
+		t.Fatalf("local delete calls = %d, want 1 during GitHub outage", got)
+	}
+}
+
+func TestRestartUnknownResourcesCountAndBlockAllocation(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-unknown-1", State: "running"}, {Name: "epar-test-unknown-2", State: "running"}}}
+	g := &fakeGitHub{listErr: &gh.HTTPError{StatusCode: 503}}
+	manager := newRegisteredTestManager(t, p, g)
+	active, err := manager.reconcilePhysicalPool(context.Background(), nil, true)
+	if err == nil {
+		t.Fatal("reconcilePhysicalPool() error = nil, want GitHub outage")
+	}
+	if len(active) != 2 {
+		t.Fatalf("counted physical resources = %d, want 2", len(active))
+	}
+	for name, vm := range active {
+		if vm.Phase != LifecycleQuarantined {
+			t.Fatalf("%s phase = %q, want quarantined", name, vm.Phase)
+		}
+	}
+	if got := atomic.LoadInt32(&p.cloneCalls); got != 0 {
+		t.Fatalf("clone calls = %d, want 0 while dependency state is ambiguous", got)
+	}
+}
+
+func TestLegacyOverCapacityInventoryBlocksAllocation(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-existing-1", State: "running"}, {Name: "epar-test-existing-2", State: "running"}, {Name: "epar-test-existing-3", State: "running"}}}
+	manager := newRegisteredTestManager(t, p, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := manager.RunPool(ctx, RunOptions{Instances: 2, KeepOnExit: true, PoolLockHeld: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&p.cloneCalls); got != 0 {
+		t.Fatalf("clone calls = %d, want 0 while legacy physical inventory exceeds target", got)
+	}
+}
+
+func TestLegacyIdleOverCapacityIsReducedToTarget(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-existing-1", State: "running"}, {Name: "epar-test-existing-2", State: "running"}, {Name: "epar-test-existing-3", State: "running"}}}
+	g := &fakeGitHub{
+		listRunners: []gh.Runner{{Name: "epar-test-existing-1", ID: 1, Status: "online"}, {Name: "epar-test-existing-2", ID: 2, Status: "online"}, {Name: "epar-test-existing-3", ID: 3, Status: "online"}},
+		runner:      gh.Runner{ID: 9, Status: "online"},
+		found:       true,
+	}
+	manager := newRegisteredTestManager(t, p, g)
+	active, err := manager.reconcilePhysicalPool(context.Background(), nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err = manager.reduceOverCapacity(context.Background(), active, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("active count = %d, want target 1", len(active))
+	}
+	if got := atomic.LoadInt32(&p.deleteCalls); got != 2 {
+		t.Fatalf("local delete calls = %d, want 2 idle excess runners retired", got)
+	}
+}
+
+func TestQuarantinedRunnersAdoptOrRetireAfterGitHubRecovery(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-healthy", State: "running"}, {Name: "epar-test-offline", State: "running"}}}
+	g := &fakeGitHub{listRunners: []gh.Runner{{Name: "epar-test-healthy", ID: 1, Status: "online"}, {Name: "epar-test-offline", ID: 2, Status: "offline"}}}
+	manager := newRegisteredTestManager(t, p, g)
+	known := map[string]ProvisionedInstance{
+		"epar-test-healthy": {Name: "epar-test-healthy", Phase: LifecycleQuarantined},
+		"epar-test-offline": {Name: "epar-test-offline", Phase: LifecycleQuarantined},
+	}
+	active, err := manager.reconcilePhysicalPool(context.Background(), known, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := active["epar-test-healthy"].Phase; got != LifecycleReady {
+		t.Fatalf("healthy phase = %q, want ready", got)
+	}
+	if _, found := active["epar-test-offline"]; found {
+		t.Fatal("offline quarantined runner survived recovery reconciliation")
+	}
+	if got := atomic.LoadInt32(&p.deleteCalls); got != 1 {
+		t.Fatalf("local delete calls = %d, want offline runner retirement", got)
+	}
+}
+
+func TestReplacementBackoffSequenceJitterCapRetryAfterAndReset(t *testing.T) {
+	manager := Manager{Config: config.Config{Pool: config.PoolConfig{
+		ReplacementRetryInitialSeconds: 15,
+		ReplacementRetryMaxSeconds:     1800,
+		ReplacementRetryMultiplier:     2,
+		ReplacementRetryJitterPercent:  20,
+	}}, randomFloat64: func() float64 { return 0.5 }}
+	now := time.Unix(1_000, 0)
+	state := replacementRetryState{}
+	want := []time.Duration{15, 30, 60, 120, 240, 480, 960, 1800, 1800}
+	for i, seconds := range want {
+		state.schedule(&manager, now, errors.New("ServiceUnavailable"))
+		if got := state.next.Sub(now); got != seconds*time.Second {
+			t.Fatalf("attempt %d delay = %s, want %s", i+1, got, seconds*time.Second)
+		}
+		now = state.next
+	}
+	state.reset()
+	if state.attempt != 0 || !state.next.IsZero() {
+		t.Fatalf("reset state = %#v", state)
+	}
+	state = replacementRetryState{attempt: 4, next: now.Add(time.Hour)}
+	before := map[string]ProvisionedInstance{"runner": {Name: "runner", Phase: LifecycleQuarantined}}
+	after := map[string]ProvisionedInstance{"runner": {Name: "runner", Phase: LifecycleReady}}
+	state.resetAfterAdoption(before, after)
+	if state.attempt != 0 || !state.next.IsZero() {
+		t.Fatalf("adoption reset state = %#v", state)
+	}
+	state.schedule(&manager, now, &gh.HTTPError{StatusCode: 429, RetryAfter: 45 * time.Second})
+	if got := state.next.Sub(now); got != 45*time.Second {
+		t.Fatalf("Retry-After delay = %s, want 45s", got)
+	}
+	low := Manager{Config: manager.Config, randomFloat64: func() float64 { return 0 }}
+	lowState := replacementRetryState{}
+	lowState.schedule(&low, now, errors.New("ServiceUnavailable"))
+	if got := lowState.next.Sub(now); got != 12*time.Second {
+		t.Fatalf("low jitter delay = %s, want 12s", got)
+	}
+	high := Manager{Config: manager.Config, randomFloat64: func() float64 { return 1 }}
+	highState := replacementRetryState{attempt: 20}
+	highState.schedule(&high, now, errors.New("ServiceUnavailable"))
+	if got := highState.next.Sub(now); got != 1800*time.Second {
+		t.Fatalf("jittered cap delay = %s, want 30m", got)
+	}
+	minimum := Manager{Config: config.Config{Pool: config.PoolConfig{
+		ReplacementRetryInitialSeconds: 1,
+		ReplacementRetryMaxSeconds:     1,
+		ReplacementRetryMultiplier:     1,
+		ReplacementRetryJitterPercent:  100,
+	}}, randomFloat64: func() float64 { return 0 }}
+	minimumState := replacementRetryState{}
+	minimumState.schedule(&minimum, now, errors.New("ServiceUnavailable"))
+	if got := minimumState.next.Sub(now); got != time.Second {
+		t.Fatalf("minimum jittered delay = %s, want 1s", got)
+	}
+}
+
+func TestTransientDependencyClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "network", err: &net.DNSError{IsTimeout: true}, want: true},
+		{name: "rate limit", err: &gh.HTTPError{StatusCode: http.StatusTooManyRequests}, want: true},
+		{name: "server error", err: &gh.HTTPError{StatusCode: http.StatusBadGateway}, want: true},
+		{name: "guest opaque 501", err: errors.New("Response status code does not indicate success: 501 (Not Implemented)"), want: true},
+		{name: "guest opaque 599", err: errors.New("Http response code: 599 from runner-registration"), want: true},
+		{name: "unauthorized", err: &gh.HTTPError{StatusCode: http.StatusUnauthorized}, want: false},
+		{name: "forbidden", err: &gh.HTTPError{StatusCode: http.StatusForbidden}, want: false},
+		{name: "guest opaque forbidden", err: errors.New("Response status code does not indicate success: 403 (Forbidden)"), want: false},
+		{name: "cancellation", err: context.Canceled, want: false},
+		{name: "deterministic configuration", err: errors.New("runner labels are invalid"), want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isTransientDependencyError(test.err); got != test.want {
+				t.Fatalf("isTransientDependencyError(%v) = %t, want %t", test.err, got, test.want)
+			}
+		})
+	}
+}
+
+func TestReplacementCooldownSkipsGitHubButContinuesLocalHousekeeping(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-existing", State: "running"}}}
+	g := &fakeGitHub{runner: gh.Runner{Name: "epar-test-existing", ID: 1, Status: "online"}, found: true}
+	g.listFunc = func(context.Context) ([]gh.Runner, error) {
+		if atomic.LoadInt32(&g.listCalls) == 1 {
+			return []gh.Runner{{Name: "epar-test-existing", ID: 1, Status: "online"}}, nil
+		}
+		p.mu.Lock()
+		if len(p.instances) > 0 {
+			p.instances[0].State = "stopped"
+		}
+		p.mu.Unlock()
+		return nil, &gh.HTTPError{StatusCode: 503}
+	}
+	manager := newRegisteredTestManager(t, p, g)
+	manager.Config.Pool.ReplacementRetryInitialSeconds = 15
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if err := manager.RunPool(ctx, RunOptions{Instances: 1, Register: true, KeepOnExit: true, ReplaceCompleted: true, MonitorInterval: time.Millisecond, PoolLockHeld: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&g.listCalls); got != 2 {
+		t.Fatalf("GitHub ListRunners calls = %d, want initial success plus one failed retry trigger", got)
+	}
+	if got := atomic.LoadInt32(&g.runnerByNameCalls); got > 1 {
+		t.Fatalf("GitHub RunnerByName calls = %d, want no calls during cooldown", got)
+	}
+	if got := atomic.LoadInt32(&p.listCalls); got <= 2 {
+		t.Fatalf("local List calls = %d, want repeated housekeeping during cooldown", got)
+	}
+	if got := atomic.LoadInt32(&p.deleteCalls); got != 1 {
+		t.Fatalf("local delete calls = %d, want stopped resource cleanup during cooldown", got)
+	}
+	if got := atomic.LoadInt32(&p.cloneCalls); got != 0 {
+		t.Fatalf("clone calls = %d, want allocation paused during cooldown", got)
+	}
+}
+
 func newRegisteredTestManager(t *testing.T, provider provider.Provider, github GitHubClient) Manager {
 	t.Helper()
 	return Manager{
@@ -748,31 +1197,45 @@ func newRegisteredTestManager(t *testing.T, provider provider.Provider, github G
 }
 
 type fakeProvider struct {
-	execErr  error
-	execErrs []error
-	execFunc func(context.Context, string, []string, provider.ExecOptions) (provider.ExecResult, error)
-	ip       string
-	mu       sync.Mutex
+	execErr   error
+	execErrs  []error
+	execFunc  func(context.Context, string, []string, provider.ExecOptions) (provider.ExecResult, error)
+	ip        string
+	cloneErr  error
+	startErr  error
+	ipErr     error
+	deleteErr error
+	listErr   error
+	mu        sync.Mutex
 
-	configureEnv map[string]string
-	commands     []string
-	execOptions  []provider.ExecOptions
-	instances    []provider.Instance
+	configureEnv     map[string]string
+	configureOptions provider.ExecOptions
+	commands         []string
+	execOptions      []provider.ExecOptions
+	instances        []provider.Instance
 
 	cloneCalls        int32
 	execCalls         int32
 	stopCalls         int32
 	deleteCalls       int32
 	canceledListCalls int32
+	maxInventory      int32
+	listCalls         int32
 }
 
-func (p *fakeProvider) Clone(context.Context, string, string) error {
+func (p *fakeProvider) Clone(_ context.Context, source, name string) error {
 	atomic.AddInt32(&p.cloneCalls, 1)
-	return nil
+	p.mu.Lock()
+	p.instances = append(p.instances, provider.Instance{Name: name, Source: source, State: "running"})
+	if len(p.instances) > int(atomic.LoadInt32(&p.maxInventory)) {
+		atomic.StoreInt32(&p.maxInventory, int32(len(p.instances)))
+	}
+	p.mu.Unlock()
+	return p.cloneErr
 }
 
 func (p *fakeProvider) Start(context.Context, string, provider.StartOptions) (*provider.RunningProcess, error) {
-	return &provider.RunningProcess{}, nil
+	return &provider.RunningProcess{}, p.startErr
 }
 
 func (p *fakeProvider) Exec(ctx context.Context, name string, command []string, opts provider.ExecOptions) (provider.ExecResult, error) {
@@ -787,6 +1250,7 @@ func (p *fakeProvider) Exec(ctx context.Context, name string, command []string, 
 		for key, value := range opts.Env {
 			p.configureEnv[key] = value
 		}
+		p.configureOptions = opts
 		p.mu.Unlock()
 	}
 	call := atomic.AddInt32(&p.execCalls, 1)
@@ -823,6 +1287,9 @@ func (p *fakeProvider) logPathFor(fragment string) string {
 }
 
 func (p *fakeProvider) IP(context.Context, string, int) (string, error) {
+	if p.ipErr != nil {
+		return "", p.ipErr
+	}
 	if p.ip == "" {
 		return "127.0.0.1", nil
 	}
@@ -834,17 +1301,32 @@ func (p *fakeProvider) Stop(context.Context, string) error {
 	return nil
 }
 
-func (p *fakeProvider) Delete(context.Context, string) error {
+func (p *fakeProvider) Delete(_ context.Context, name string) error {
 	atomic.AddInt32(&p.deleteCalls, 1)
+	if p.deleteErr != nil {
+		return p.deleteErr
+	}
+	p.mu.Lock()
+	remaining := p.instances[:0]
+	for _, instance := range p.instances {
+		if instance.Name != name {
+			remaining = append(remaining, instance)
+		}
+	}
+	p.instances = remaining
+	p.mu.Unlock()
 	return nil
 }
 
 func (p *fakeProvider) List(ctx context.Context) ([]provider.Instance, error) {
+	atomic.AddInt32(&p.listCalls, 1)
 	if ctx.Err() != nil {
 		atomic.AddInt32(&p.canceledListCalls, 1)
 		return nil, ctx.Err()
 	}
-	return append([]provider.Instance(nil), p.instances...), nil
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]provider.Instance(nil), p.instances...), p.listErr
 }
 
 type fakeGitHub struct {
@@ -857,6 +1339,16 @@ type fakeGitHub struct {
 	deleteErr           error
 	waitOnlineCalls     int32
 	waitOnlineIdleCalls int32
+	listRunners         []gh.Runner
+	listErr             error
+	listFunc            func(context.Context) ([]gh.Runner, error)
+	registrationErr     error
+	registrationToken   string
+	deleteCalls         int32
+	deletedIDs          []int64
+	mu                  sync.Mutex
+	listCalls           int32
+	runnerByNameCalls   int32
 }
 
 func (g *fakeGitHub) OrganizationURL() string {
@@ -864,17 +1356,23 @@ func (g *fakeGitHub) OrganizationURL() string {
 }
 
 func (g *fakeGitHub) RegistrationToken(context.Context) (gh.RegistrationToken, error) {
-	return gh.RegistrationToken{Token: "token"}, nil
+	token := g.registrationToken
+	if token == "" {
+		token = "token"
+	}
+	return gh.RegistrationToken{Token: token}, g.registrationErr
 }
 
-func (g *fakeGitHub) ListRunners(context.Context) ([]gh.Runner, error) {
-	if !g.found {
-		return nil, nil
+func (g *fakeGitHub) ListRunners(ctx context.Context) ([]gh.Runner, error) {
+	atomic.AddInt32(&g.listCalls, 1)
+	if g.listFunc != nil {
+		return g.listFunc(ctx)
 	}
-	return []gh.Runner{g.runner}, nil
+	return append([]gh.Runner(nil), g.listRunners...), g.listErr
 }
 
 func (g *fakeGitHub) RunnerByName(context.Context, string) (gh.Runner, bool, error) {
+	atomic.AddInt32(&g.runnerByNameCalls, 1)
 	return g.runner, g.found, g.runnerErr
 }
 
@@ -901,7 +1399,11 @@ func (g *fakeGitHub) waitReady(ctx context.Context, name string, timeout time.Du
 	return g.runner, nil
 }
 
-func (g *fakeGitHub) DeleteRunnerIfExists(context.Context, int64) error {
+func (g *fakeGitHub) DeleteRunnerIfExists(_ context.Context, id int64) error {
+	atomic.AddInt32(&g.deleteCalls, 1)
+	g.mu.Lock()
+	g.deletedIDs = append(g.deletedIDs, id)
+	g.mu.Unlock()
 	return g.deleteErr
 }
 

--- a/internal/pool/runner_script_test.go
+++ b/internal/pool/runner_script_test.go
@@ -220,6 +220,62 @@ exit 0
 	}
 }
 
+func TestConfigureRunnerReadsTokenFromStdin(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "config.args")
+	for name, content := range map[string]string{
+		"sudo": `#!/usr/bin/env bash
+if [[ "${1:-}" == "-u" ]]; then
+  shift 2
+fi
+exec "$@"
+`,
+		"config.sh": `#!/usr/bin/env bash
+printf '%s\n' "$@" >"${EPAR_CONFIG_ARGS_FILE}"
+`,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	script := filepath.ToSlash(filepath.Join("..", "..", "scripts", "guest", "ubuntu", "configure-runner.sh"))
+	cmd := exec.Command(gitBashForRunnerScriptTest(t), script)
+	cmd.Stdin = strings.NewReader(secret + "\n")
+	cmd.Env = append(os.Environ(),
+		"RUNNER_URL=https://github.test/example",
+		"RUNNER_NAME=epar-test",
+		"RUNNER_LABELS=self-hosted",
+		"EPAR_ACTIONS_RUNNER_DIR="+bashPath(dir),
+		"EPAR_CONFIG_ARGS_FILE="+bashPath(argsFile),
+		"PATH="+bashPath(dir)+":"+os.Getenv("PATH"),
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("configure-runner stdin token path failed: %v\n%s", err, out)
+	}
+	args, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "--token\n"+secret+"\n") {
+		t.Fatalf("config.sh arguments did not receive stdin token: %q", args)
+	}
+
+	cmd = exec.Command(gitBashForRunnerScriptTest(t), script)
+	cmd.Env = append(os.Environ(),
+		"RUNNER_URL=https://github.test/example",
+		"RUNNER_NAME=epar-test",
+		"RUNNER_LABELS=self-hosted",
+		"EPAR_ACTIONS_RUNNER_DIR="+bashPath(dir),
+		"PATH="+bashPath(dir)+":"+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil || !strings.Contains(string(out), "must be provided as one nonempty line on stdin") {
+		t.Fatalf("configure-runner empty stdin error = %v, output = %q", err, out)
+	}
+}
+
 func requireLinuxProc(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS != "linux" {
@@ -582,7 +638,7 @@ func TestCollectRunnerDiagnosticsValidatesTailLines(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			command := fmt.Sprintf("EPAR_DIAGNOSTIC_TAIL_LINES=%s exec bash %s", tc.value, script)
-			cmd := exec.Command("bash", "-c", command)
+			cmd := exec.Command(gitBashForRunnerScriptTest(t), "-c", command)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("collect-runner-diagnostics.sh failed: %v\n%s", err, out)

--- a/internal/pool/startup_timing.go
+++ b/internal/pool/startup_timing.go
@@ -5,13 +5,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
-)
 
-var timingSecretPattern = regexp.MustCompile(`(?i)((?:runner_)?token|password|secret|private[_-]?key)=\S+`)
+	"github.com/solutionforest/ephemeral-action-runner/internal/provider"
+)
 
 type startupTimingEvent struct {
 	Timestamp string `json:"timestamp"`
@@ -190,10 +189,7 @@ func startupTimingLabel(provider string) string {
 }
 
 func sanitizeTimingError(err error) string {
-	text := strings.Join(strings.Fields(err.Error()), " ")
-	text = timingSecretPattern.ReplaceAllStringFunc(text, func(match string) string {
-		return match[:strings.Index(match, "=")+1] + "[REDACTED]"
-	})
+	text := provider.RedactText(strings.Join(strings.Fields(err.Error()), " "))
 	if len(text) > 500 {
 		return text[:500] + "..."
 	}

--- a/internal/pool/startup_timing_test.go
+++ b/internal/pool/startup_timing_test.go
@@ -1,0 +1,18 @@
+package pool
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeTimingErrorRedactsSecretAssignments(t *testing.T) {
+	const sentinel = "timing-secret-sentinel"
+	got := sanitizeTimingError(errors.New("configure failed RUNNER_TOKEN=" + sentinel + " PASSWORD=" + sentinel))
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("sanitizeTimingError leaked sentinel: %q", got)
+	}
+	if !strings.Contains(got, "RUNNER_TOKEN=[REDACTED]") || !strings.Contains(got, "PASSWORD=[REDACTED]") {
+		t.Fatalf("sanitizeTimingError did not retain sanitized keys: %q", got)
+	}
+}

--- a/internal/provider/dockerdind/docker_dind.go
+++ b/internal/provider/dockerdind/docker_dind.go
@@ -72,7 +72,7 @@ func (p *Provider) Exec(ctx context.Context, name string, command []string, opts
 	if opts.Stdin != "" {
 		stdin = strings.NewReader(opts.Stdin)
 	}
-	return p.runWithLog(ctx, stdin, opts.LogPath, opts.Stdout, opts.Stderr, args...)
+	return p.runWithSensitiveLog(ctx, stdin, opts.LogPath, opts.Stdout, opts.Stderr, opts.SensitiveValues, args...)
 }
 
 func (p *Provider) IP(ctx context.Context, name string, waitSeconds int) (string, error) {
@@ -199,11 +199,21 @@ func (p *Provider) run(ctx context.Context, stdin io.Reader, args ...string) (pr
 }
 
 func (p *Provider) runWithLog(ctx context.Context, stdin io.Reader, logPath string, stdoutSink, stderrSink io.Writer, args ...string) (provider.ExecResult, error) {
+	return p.runWithSensitiveLog(ctx, stdin, logPath, stdoutSink, stderrSink, nil, args...)
+}
+
+func (p *Provider) runWithSensitiveLog(ctx context.Context, stdin io.Reader, logPath string, stdoutSink, stderrSink io.Writer, sensitiveValues []string, args ...string) (provider.ExecResult, error) {
+	bufferedStdout, bufferedStderr, flush := provider.BufferSensitiveSinks(sensitiveValues, stdoutSink, stderrSink)
+	result, err := p.runWithLogRaw(ctx, stdin, logPath, bufferedStdout, bufferedStderr, sensitiveValues, args...)
+	return provider.FinishSensitiveExecution(result, err, flush(), sensitiveValues)
+}
+
+func (p *Provider) runWithLogRaw(ctx context.Context, stdin io.Reader, logPath string, stdoutSink, stderrSink io.Writer, sensitiveValues []string, args ...string) (provider.ExecResult, error) {
 	if p.runCommand != nil {
 		return p.runCommand(ctx, stdin, logPath, stdoutSink, stderrSink, args...)
 	}
 	if p.DryRun {
-		fmt.Printf("[dry-run] %s %s\n", p.Binary, strings.Join(args, " "))
+		fmt.Printf("[dry-run] %s %s\n", p.Binary, provider.RedactText(strings.Join(args, " "), sensitiveValues...))
 		return provider.ExecResult{}, nil
 	}
 	cmd := exec.CommandContext(ctx, p.Binary, args...)

--- a/internal/provider/dockerdind/docker_dind_test.go
+++ b/internal/provider/dockerdind/docker_dind_test.go
@@ -95,6 +95,43 @@ func TestExecArgsPreserveEnvAndStdin(t *testing.T) {
 	}
 }
 
+func TestExecRedactsSensitiveValuesFromResultErrorAndSinks(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	p := New("docker", "", false)
+	var stdout, stderr bytes.Buffer
+	p.runCommand = func(_ context.Context, _ io.Reader, _ string, gotStdout, gotStderr io.Writer, args ...string) (provider.ExecResult, error) {
+		_, _ = gotStdout.Write([]byte("stream " + secret))
+		_, _ = gotStderr.Write([]byte("RUNNER_TOKEN=" + secret))
+		return provider.ExecResult{Stdout: "result " + secret, Stderr: "SECRET=" + secret}, errors.New("docker " + strings.Join(args, " ") + " failed with " + secret)
+	}
+	result, err := p.Exec(context.Background(), "runner", []string{"false"}, provider.ExecOptions{
+		Env:             map[string]string{"RUNNER_TOKEN": secret},
+		SensitiveValues: []string{secret},
+		Stdout:          &stdout,
+		Stderr:          &stderr,
+	})
+	combined := stdout.String() + stderr.String() + result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("sensitive Docker exec leaked secret: %q", combined)
+	}
+}
+
+func TestExecRedactsSecretAssignmentsWithoutSensitiveValues(t *testing.T) {
+	const secret = "ordinary-sentinel"
+	p := New("docker", "", false)
+	var stdout, stderr bytes.Buffer
+	p.runCommand = func(_ context.Context, _ io.Reader, _ string, gotStdout, gotStderr io.Writer, _ ...string) (provider.ExecResult, error) {
+		_, _ = gotStdout.Write([]byte("PASSWORD=" + secret + "\n"))
+		_, _ = gotStderr.Write([]byte("SECRET=" + secret + "\n"))
+		return provider.ExecResult{Stdout: "TOKEN=" + secret, Stderr: "PRIVATE_KEY=" + secret}, errors.New("RUNNER_TOKEN=" + secret)
+	}
+	result, err := p.Exec(context.Background(), "runner", []string{"false"}, provider.ExecOptions{Stdout: &stdout, Stderr: &stderr})
+	combined := stdout.String() + stderr.String() + result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("ordinary Docker exec leaked secret assignment: %q", combined)
+	}
+}
+
 func TestListParsesDockerPSOutput(t *testing.T) {
 	p := New("docker", "", false)
 	p.runCommand = func(_ context.Context, _ io.Reader, _ string, _, _ io.Writer, args ...string) (provider.ExecResult, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,11 +28,12 @@ type RunningProcess struct {
 }
 
 type ExecOptions struct {
-	Stdin   string
-	Env     map[string]string
-	LogPath string
-	Stdout  io.Writer
-	Stderr  io.Writer
+	Stdin           string
+	Env             map[string]string
+	SensitiveValues []string
+	LogPath         string
+	Stdout          io.Writer
+	Stderr          io.Writer
 }
 
 type ExecResult struct {

--- a/internal/provider/redaction.go
+++ b/internal/provider/redaction.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const redactedValue = "[REDACTED]"
+
+var sensitiveAssignmentPattern = regexp.MustCompile(`(?i)([[:alnum:]_.-]*(?:token|password|secret|private(?:[_-]?key)?)[[:alnum:]_.-]*=)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^[:space:]]+)`)
+
+// RedactText removes exact sensitive values and conservative KEY=value secret
+// assignments from text before it is returned, logged, or persisted.
+func RedactText(text string, sensitiveValues ...string) string {
+	values := nonemptySensitiveValues(sensitiveValues)
+	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	for _, value := range values {
+		text = strings.ReplaceAll(text, value, redactedValue)
+	}
+	return sensitiveAssignmentPattern.ReplaceAllString(text, `${1}`+redactedValue)
+}
+
+func HasSensitiveValues(values []string) bool {
+	return len(nonemptySensitiveValues(values)) > 0
+}
+
+func RedactExecResult(result ExecResult, sensitiveValues ...string) ExecResult {
+	result.Stdout = RedactText(result.Stdout, sensitiveValues...)
+	result.Stderr = RedactText(result.Stderr, sensitiveValues...)
+	return result
+}
+
+func RedactError(err error, sensitiveValues ...string) error {
+	if err == nil {
+		return nil
+	}
+	redacted := RedactText(err.Error(), sensitiveValues...)
+	if redacted == err.Error() {
+		return err
+	}
+	return redactedError{message: redacted, cause: err}
+}
+
+type redactedError struct {
+	message string
+	cause   error
+}
+
+func (err redactedError) Error() string { return err.message }
+
+func (err redactedError) Unwrap() error { return err.cause }
+
+// BufferSensitiveSinks fully buffers executions carrying exact sensitive
+// values. Ordinary executions retain line-level streaming while conservative
+// KEY=value secret assignments are redacted before reaching either sink.
+func BufferSensitiveSinks(sensitiveValues []string, stdout, stderr io.Writer) (io.Writer, io.Writer, func() error) {
+	if !HasSensitiveValues(sensitiveValues) {
+		stdoutRedactor := newLineRedactingWriter(stdout)
+		stderrRedactor := newLineRedactingWriter(stderr)
+		return stdoutRedactor, stderrRedactor, func() error {
+			return errors.Join(stdoutRedactor.Flush(), stderrRedactor.Flush())
+		}
+	}
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	flush := func() error {
+		return errors.Join(
+			writeRedacted(&stdoutBuffer, stdout, sensitiveValues),
+			writeRedacted(&stderrBuffer, stderr, sensitiveValues),
+		)
+	}
+	return &stdoutBuffer, &stderrBuffer, flush
+}
+
+type lineRedactingWriter struct {
+	destination io.Writer
+	buffer      bytes.Buffer
+}
+
+func newLineRedactingWriter(destination io.Writer) *lineRedactingWriter {
+	return &lineRedactingWriter{destination: destination}
+}
+
+func (writer *lineRedactingWriter) Write(data []byte) (int, error) {
+	written := len(data)
+	if writer.destination == nil {
+		return written, nil
+	}
+	if _, err := writer.buffer.Write(data); err != nil {
+		return 0, err
+	}
+	for {
+		delimiter := bytes.IndexAny(writer.buffer.Bytes(), "\r\n")
+		if delimiter < 0 {
+			break
+		}
+		line := append([]byte(nil), writer.buffer.Next(delimiter+1)...)
+		if err := writer.writeRedacted(string(line)); err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
+
+func (writer *lineRedactingWriter) Flush() error {
+	if writer.buffer.Len() == 0 {
+		return nil
+	}
+	remaining := writer.buffer.String()
+	writer.buffer.Reset()
+	return writer.writeRedacted(remaining)
+}
+
+func (writer *lineRedactingWriter) writeRedacted(text string) error {
+	if writer.destination == nil {
+		return nil
+	}
+	redacted := RedactText(text)
+	written, err := io.WriteString(writer.destination, redacted)
+	if err == nil && written != len(redacted) {
+		return io.ErrShortWrite
+	}
+	return err
+}
+
+func FinishSensitiveExecution(result ExecResult, runErr, sinkErr error, sensitiveValues []string) (ExecResult, error) {
+	result = RedactExecResult(result, sensitiveValues...)
+	return result, errors.Join(RedactError(runErr, sensitiveValues...), sinkErr)
+}
+
+func writeRedacted(source *bytes.Buffer, destination io.Writer, sensitiveValues []string) error {
+	if destination == nil || source.Len() == 0 {
+		return nil
+	}
+	redacted := RedactText(source.String(), sensitiveValues...)
+	written, err := io.WriteString(destination, redacted)
+	if err == nil && written != len(redacted) {
+		return io.ErrShortWrite
+	}
+	return err
+}
+
+func nonemptySensitiveValues(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/provider/redaction_test.go
+++ b/internal/provider/redaction_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRedactTextRemovesExactValuesAndSecretAssignments(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	input := "docker exec -e RUNNER_TOKEN=" + secret + " PASSWORD=hunter2 normal=value exact=" + secret
+	got := RedactText(input, secret)
+	if strings.Contains(got, secret) || strings.Contains(got, "hunter2") {
+		t.Fatalf("RedactText() leaked a secret: %q", got)
+	}
+	for _, want := range []string{"RUNNER_TOKEN=[REDACTED]", "PASSWORD=[REDACTED]", "exact=[REDACTED]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RedactText() = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestBufferSensitiveSinksRedactsBeforeWriting(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	var stdout, stderr bytes.Buffer
+	bufferedStdout, bufferedStderr, flush := BufferSensitiveSinks([]string{secret}, &stdout, &stderr)
+	_, _ = bufferedStdout.Write([]byte("out " + secret))
+	_, _ = bufferedStderr.Write([]byte("RUNNER_TOKEN=" + secret))
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatal("sensitive output streamed before redaction")
+	}
+	if err := flush(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String()+stderr.String(), secret) {
+		t.Fatalf("sensitive sinks leaked secret: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestBufferSensitiveSinksRedactsOrdinaryOutputAcrossChunks(t *testing.T) {
+	var stdout bytes.Buffer
+	bufferedStdout, _, flush := BufferSensitiveSinks(nil, &stdout, nil)
+	_, _ = bufferedStdout.Write([]byte("ordinary line\nPASS"))
+	if got := stdout.String(); got != "ordinary line\n" {
+		t.Fatalf("ordinary complete-line streaming = %q", got)
+	}
+	_, _ = bufferedStdout.Write([]byte("WORD=sentinel\n"))
+	if err := flush(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String(), "sentinel") {
+		t.Fatalf("ordinary sink leaked chunked secret assignment: %q", stdout.String())
+	}
+}
+
+func TestFinishSensitiveExecutionRedactsResultAndError(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	sentinel := errors.New("sentinel cause")
+	result, err := FinishSensitiveExecution(
+		ExecResult{Stdout: secret, Stderr: "TOKEN=" + secret},
+		fmt.Errorf("command failed with %s: %w", secret, sentinel),
+		nil,
+		[]string{secret},
+	)
+	combined := result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("sensitive execution outcome leaked secret: %q", combined)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("redacted error no longer wraps original cause: %v", err)
+	}
+}

--- a/internal/provider/tart/tart.go
+++ b/internal/provider/tart/tart.go
@@ -12,9 +12,12 @@ import (
 )
 
 type Provider struct {
-	Binary string
-	DryRun bool
+	Binary     string
+	DryRun     bool
+	runCommand runCommandFunc
 }
+
+type runCommandFunc func(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args ...string) (provider.ExecResult, error)
 
 func New(binary string, dryRun bool) *Provider {
 	if binary == "" {
@@ -66,7 +69,7 @@ func (p *Provider) Exec(ctx context.Context, name string, command []string, opts
 	}
 	full = append(full, name)
 	full = append(full, provider.EnvCommand(opts.Env, command)...)
-	return p.runWithLog(ctx, strings.NewReader(opts.Stdin), opts.Stdout, opts.Stderr, full...)
+	return p.runWithSensitiveLog(ctx, strings.NewReader(opts.Stdin), opts.Stdout, opts.Stderr, opts.SensitiveValues, full...)
 }
 
 func (p *Provider) IP(ctx context.Context, name string, waitSeconds int) (string, error) {
@@ -115,8 +118,21 @@ func (p *Provider) run(ctx context.Context, stdin io.Reader, args ...string) (pr
 }
 
 func (p *Provider) runWithLog(ctx context.Context, stdin io.Reader, stdoutSink, stderrSink io.Writer, args ...string) (provider.ExecResult, error) {
+	return p.runWithSensitiveLog(ctx, stdin, stdoutSink, stderrSink, nil, args...)
+}
+
+func (p *Provider) runWithSensitiveLog(ctx context.Context, stdin io.Reader, stdoutSink, stderrSink io.Writer, sensitiveValues []string, args ...string) (provider.ExecResult, error) {
+	bufferedStdout, bufferedStderr, flush := provider.BufferSensitiveSinks(sensitiveValues, stdoutSink, stderrSink)
+	result, err := p.runWithLogRaw(ctx, stdin, bufferedStdout, bufferedStderr, sensitiveValues, args...)
+	return provider.FinishSensitiveExecution(result, err, flush(), sensitiveValues)
+}
+
+func (p *Provider) runWithLogRaw(ctx context.Context, stdin io.Reader, stdoutSink, stderrSink io.Writer, sensitiveValues []string, args ...string) (provider.ExecResult, error) {
+	if p.runCommand != nil {
+		return p.runCommand(ctx, stdin, stdoutSink, stderrSink, args...)
+	}
 	if p.DryRun {
-		fmt.Printf("[dry-run] %s %s\n", p.Binary, strings.Join(args, " "))
+		fmt.Printf("[dry-run] %s %s\n", p.Binary, provider.RedactText(strings.Join(args, " "), sensitiveValues...))
 		return provider.ExecResult{}, nil
 	}
 	cmd := exec.CommandContext(ctx, p.Binary, args...)

--- a/internal/provider/tart/tart_test.go
+++ b/internal/provider/tart/tart_test.go
@@ -3,6 +3,7 @@ package tart
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -30,6 +31,43 @@ func TestCaptureWriterCopiesToCaptureAndInjectedSink(t *testing.T) {
 	}
 	if capture.String() != "transcript" || sink.String() != "transcript" {
 		t.Fatalf("capture=%q sink=%q", capture.String(), sink.String())
+	}
+}
+
+func TestExecRedactsSensitiveValuesFromResultErrorAndSinks(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	p := New("tart", false)
+	var stdout, stderr bytes.Buffer
+	p.runCommand = func(_ context.Context, _ io.Reader, gotStdout, gotStderr io.Writer, args ...string) (provider.ExecResult, error) {
+		_, _ = gotStdout.Write([]byte("stream " + secret))
+		_, _ = gotStderr.Write([]byte("RUNNER_TOKEN=" + secret))
+		return provider.ExecResult{Stdout: "result " + secret, Stderr: "SECRET=" + secret}, errors.New("tart " + strings.Join(args, " ") + " failed with " + secret)
+	}
+	result, err := p.Exec(context.Background(), "runner", []string{"false"}, provider.ExecOptions{
+		Env:             map[string]string{"RUNNER_TOKEN": secret},
+		SensitiveValues: []string{secret},
+		Stdout:          &stdout,
+		Stderr:          &stderr,
+	})
+	combined := stdout.String() + stderr.String() + result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("sensitive Tart exec leaked secret: %q", combined)
+	}
+}
+
+func TestExecRedactsSecretAssignmentsWithoutSensitiveValues(t *testing.T) {
+	const secret = "ordinary-sentinel"
+	p := New("tart", false)
+	var stdout, stderr bytes.Buffer
+	p.runCommand = func(_ context.Context, _ io.Reader, gotStdout, gotStderr io.Writer, _ ...string) (provider.ExecResult, error) {
+		_, _ = gotStdout.Write([]byte("PASSWORD=" + secret + "\n"))
+		_, _ = gotStderr.Write([]byte("SECRET=" + secret + "\n"))
+		return provider.ExecResult{Stdout: "TOKEN=" + secret, Stderr: "PRIVATE_KEY=" + secret}, errors.New("RUNNER_TOKEN=" + secret)
+	}
+	result, err := p.Exec(context.Background(), "runner", []string{"false"}, provider.ExecOptions{Stdout: &stdout, Stderr: &stderr})
+	combined := stdout.String() + stderr.String() + result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("ordinary Tart exec leaked secret assignment: %q", combined)
 	}
 }
 

--- a/internal/provider/wsl/wsl.go
+++ b/internal/provider/wsl/wsl.go
@@ -97,7 +97,7 @@ func (p *Provider) Exec(ctx context.Context, name string, command []string, opts
 	if opts.Stdin != "" {
 		stdin = strings.NewReader(opts.Stdin)
 	}
-	return p.runWithLog(ctx, stdin, opts.LogPath, opts.Stdout, opts.Stderr, p.execArgs(name, command, opts.Env)...)
+	return p.runWithSensitiveLog(ctx, stdin, opts.LogPath, opts.Stdout, opts.Stderr, opts.SensitiveValues, p.execArgs(name, command, opts.Env)...)
 }
 
 func (p *Provider) IP(ctx context.Context, name string, waitSeconds int) (string, error) {
@@ -273,11 +273,21 @@ func (p *Provider) run(ctx context.Context, stdin io.Reader, args ...string) (pr
 }
 
 func (p *Provider) runWithLog(ctx context.Context, stdin io.Reader, logPath string, stdoutSink, stderrSink io.Writer, args ...string) (provider.ExecResult, error) {
+	return p.runWithSensitiveLog(ctx, stdin, logPath, stdoutSink, stderrSink, nil, args...)
+}
+
+func (p *Provider) runWithSensitiveLog(ctx context.Context, stdin io.Reader, logPath string, stdoutSink, stderrSink io.Writer, sensitiveValues []string, args ...string) (provider.ExecResult, error) {
+	bufferedStdout, bufferedStderr, flush := provider.BufferSensitiveSinks(sensitiveValues, stdoutSink, stderrSink)
+	result, err := p.runWithLogRaw(ctx, stdin, logPath, bufferedStdout, bufferedStderr, sensitiveValues, args...)
+	return provider.FinishSensitiveExecution(result, err, flush(), sensitiveValues)
+}
+
+func (p *Provider) runWithLogRaw(ctx context.Context, stdin io.Reader, logPath string, stdoutSink, stderrSink io.Writer, sensitiveValues []string, args ...string) (provider.ExecResult, error) {
 	if p.runCommand != nil {
 		return p.runCommand(ctx, stdin, logPath, stdoutSink, stderrSink, args...)
 	}
 	if p.DryRun {
-		fmt.Printf("[dry-run] %s %s\n", p.Binary, strings.Join(args, " "))
+		fmt.Printf("[dry-run] %s %s\n", p.Binary, provider.RedactText(strings.Join(args, " "), sensitiveValues...))
 		return provider.ExecResult{}, nil
 	}
 	cmd := exec.CommandContext(ctx, p.Binary, args...)

--- a/internal/provider/wsl/wsl_test.go
+++ b/internal/provider/wsl/wsl_test.go
@@ -38,6 +38,43 @@ func TestExecPassesInjectedTranscriptWriters(t *testing.T) {
 	}
 }
 
+func TestExecRedactsSensitiveValuesFromResultErrorAndSinks(t *testing.T) {
+	const secret = "sentinel-registration-token"
+	p := New("wsl.exe", t.TempDir(), t.TempDir(), false)
+	var stdout, stderr bytes.Buffer
+	p.runCommand = func(_ context.Context, _ io.Reader, _ string, gotStdout, gotStderr io.Writer, args ...string) (provider.ExecResult, error) {
+		_, _ = gotStdout.Write([]byte("stream " + secret))
+		_, _ = gotStderr.Write([]byte("RUNNER_TOKEN=" + secret))
+		return provider.ExecResult{Stdout: "result " + secret, Stderr: "SECRET=" + secret}, errors.New("wsl " + strings.Join(args, " ") + " failed with " + secret)
+	}
+	result, err := p.Exec(context.Background(), "runner", []string{"false"}, provider.ExecOptions{
+		Env:             map[string]string{"RUNNER_TOKEN": secret},
+		SensitiveValues: []string{secret},
+		Stdout:          &stdout,
+		Stderr:          &stderr,
+	})
+	combined := stdout.String() + stderr.String() + result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("sensitive WSL exec leaked secret: %q", combined)
+	}
+}
+
+func TestExecRedactsSecretAssignmentsWithoutSensitiveValues(t *testing.T) {
+	const secret = "ordinary-sentinel"
+	p := New("wsl.exe", t.TempDir(), t.TempDir(), false)
+	var stdout, stderr bytes.Buffer
+	p.runCommand = func(_ context.Context, _ io.Reader, _ string, gotStdout, gotStderr io.Writer, _ ...string) (provider.ExecResult, error) {
+		_, _ = gotStdout.Write([]byte("PASSWORD=" + secret + "\n"))
+		_, _ = gotStderr.Write([]byte("SECRET=" + secret + "\n"))
+		return provider.ExecResult{Stdout: "TOKEN=" + secret, Stderr: "PRIVATE_KEY=" + secret}, errors.New("RUNNER_TOKEN=" + secret)
+	}
+	result, err := p.Exec(context.Background(), "runner", []string{"false"}, provider.ExecOptions{Stdout: &stdout, Stderr: &stderr})
+	combined := stdout.String() + stderr.String() + result.Stdout + result.Stderr + err.Error()
+	if strings.Contains(combined, secret) {
+		t.Fatalf("ordinary WSL exec leaked secret assignment: %q", combined)
+	}
+}
+
 func TestCommandConstruction(t *testing.T) {
 	p := New("wsl.exe", filepath.Join("C:", "ephemeral"), `D:\repo`, true)
 	installDir, err := p.instanceDir("epar-test-1")

--- a/scripts/guest/ubuntu/configure-runner.sh
+++ b/scripts/guest/ubuntu/configure-runner.sh
@@ -2,14 +2,19 @@
 set -euo pipefail
 
 : "${RUNNER_URL:?RUNNER_URL is required}"
-: "${RUNNER_TOKEN:?RUNNER_TOKEN is required}"
 : "${RUNNER_NAME:?RUNNER_NAME is required}"
 : "${RUNNER_LABELS:?RUNNER_LABELS is required}"
 RUNNER_EPHEMERAL="${RUNNER_EPHEMERAL:-true}"
 RUNNER_GROUP="${RUNNER_GROUP:-}"
 RUNNER_NO_DEFAULT_LABELS="${RUNNER_NO_DEFAULT_LABELS:-false}"
+EPAR_ACTIONS_RUNNER_DIR="${EPAR_ACTIONS_RUNNER_DIR:-/opt/actions-runner}"
 
-cd /opt/actions-runner
+if ! IFS= read -r RUNNER_TOKEN || [[ -z "${RUNNER_TOKEN}" ]]; then
+  echo "RUNNER_TOKEN must be provided as one nonempty line on stdin" >&2
+  exit 1
+fi
+
+cd "${EPAR_ACTIONS_RUNNER_DIR}"
 if [[ -f .runner ]]; then
   sudo -u runner ./config.sh remove --token "${RUNNER_TOKEN}" || true
 fi


### PR DESCRIPTION
Enforce a strict physical pool cap with lifecycle-aware reconciliation, rollback, quarantine, controller locking, and exponential dependency backoff. Pass registration tokens through stdin, sanitize provider diagnostics, and write private error reports atomically.