### PR TITLE
test: harden transient runner probe recovery

### DIFF
--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -819,6 +819,7 @@ func TestProvisionOneRecoversFromTransientRunnerProbeFailure(t *testing.T) {
 			case 2:
 				close(ready)
 			}
+			return provider.ExecResult{Stdout: runnerProcessRunningSentinel + "\n"}, nil
 		}
 		return provider.ExecResult{}, nil
 	}


### PR DESCRIPTION
## Summary

- make the transient runner-probe recovery test return the healthy process sentinel after its intentionally injected first failure
- remove scheduler-dependent competition between the readiness goroutine and subsequent invalid fake probes
- preserve production readiness validation and lifecycle behavior unchanged

## Validation

- `go test ./internal/pool -run '^TestProvisionOneRecoversFromTransientRunnerProbeFailure$' -count=1000`
- `go test -race ./internal/pool -run '^TestProvisionOneRecoversFromTransientRunnerProbeFailure$' -count=100`
- `go test ./...`
- independent diff and lifecycle-safety verification