### PR TITLE
Harden prebuilt image publication hygiene

### DIFF
--- a/.github/workflows/docker-sandboxes-images.yml
+++ b/.github/workflows/docker-sandboxes-images.yml
@@ -5,6 +5,15 @@ on:
     - cron: '37 */6 * * *'
   push:
     branches:
+      - main
+    paths:
+      - '.github/workflows/docker-sandboxes-images.yml'
+      - 'templates/docker-sandboxes/**'
+      - 'scripts/docker-sandboxes/**'
+      - 'internal/prebuilt/**'
+      - 'cmd/epar-prebuilt-publisher/**'
+  pull_request:
+    branches:
       - develop
       - main
     paths:
@@ -61,8 +70,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: docker-sandboxes-prebuilt-publisher
-  cancel-in-progress: false
+  group: docker-sandboxes-prebuilt-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'publisher' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   SOURCE_REPOSITORY: ghcr.io/catthehacker/ubuntu
@@ -75,9 +84,35 @@ env:
   DOCKER_BUILD_RECORD_UPLOAD: 'false'
 
 jobs:
+  validate:
+    name: Validate prebuilt publication contract without publishing
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify publisher and signed-evidence contracts
+        run: go test ./internal/prebuilt ./cmd/epar-prebuilt-publisher -count=1
+
+      - name: Validate committed Docker Sandboxes assets
+        shell: pwsh
+        run: |
+          scripts/docker-sandboxes/validate-assets.ps1 -Platform linux/amd64
+          scripts/docker-sandboxes/validate-assets.ps1 -Platform linux/arm64
+
   resolve:
     name: Resolve immutable upstream and publication state
-    if: inputs.promote_candidate != true
+    if: github.event_name != 'pull_request' && inputs.promote_candidate != true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -418,7 +453,7 @@ jobs:
           echo "hook_sha=$hook_sha" >> "$GITHUB_OUTPUT"
           echo "egress_sha=$egress_sha" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push platform candidate with SBOM and provenance
+      - name: Build and push platform candidate
         id: push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -449,29 +484,46 @@ jobs:
             RUNNER_ASSET_DIGEST=${{ matrix.runner_digest }}
             ACTIONS_RUNNER_VERSION=${{ needs.resolve.outputs.runner_version }}
             ACTIONS_RUNNER_SHA256=${{ matrix.runner_digest }}
-          provenance: mode=max
-          sbom: true
+          # The signed SLSA and SPDX referrers are generated for the completed
+          # multi-platform index below. Disabling BuildKit's additional
+          # per-platform attestations avoids duplicate evidence indexes while
+          # retaining the exact runnable platform manifests in that index.
+          provenance: false
+          sbom: false
 
       - name: Record platform digest and runner tuple
         shell: bash
         env:
           PLATFORM: ${{ matrix.platform }}
           PLATFORM_SLUG: ${{ matrix.slug }}
-          CANDIDATE_INDEX_DIGEST: ${{ steps.push.outputs.digest }}
-          CANDIDATE_REFERENCE: ${{ env.PACKAGE_REPOSITORY }}:candidate-${{ needs.resolve.outputs.profile }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.slug }}
+          CANDIDATE_DESCRIPTOR_DIGEST: ${{ steps.push.outputs.digest }}
+          PACKAGE_REPOSITORY: ${{ env.PACKAGE_REPOSITORY }}
           RUNNER_VERSION: ${{ needs.resolve.outputs.runner_version }}
           RUNNER_DIGEST: ${{ matrix.runner_digest }}
         run: |
           set -euo pipefail
-          [[ "$CANDIDATE_INDEX_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
-          docker buildx imagetools inspect "$CANDIDATE_REFERENCE" --raw > "$RUNNER_TEMP/platform-candidate-index.json"
-          architecture="${PLATFORM#linux/}"
-          package_manifest_digest="$(jq -er --arg architecture "$architecture" \
-            '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture)] | if length == 1 then .[0].digest else error("expected exactly one runnable platform manifest") end' \
-            "$RUNNER_TEMP/platform-candidate-index.json")"
+          [[ "$CANDIDATE_DESCRIPTOR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          platform_candidate_ref="${PACKAGE_REPOSITORY}@${CANDIDATE_DESCRIPTOR_DIGEST}"
+          docker buildx imagetools inspect "$platform_candidate_ref" --raw > "$RUNNER_TEMP/platform-candidate-descriptor.json"
+          media_type="$(jq -er '.mediaType' "$RUNNER_TEMP/platform-candidate-descriptor.json")"
+          case "$media_type" in
+            application/vnd.oci.image.manifest.v1+json|application/vnd.docker.distribution.manifest.v2+json)
+              package_manifest_digest="$CANDIDATE_DESCRIPTOR_DIGEST"
+              ;;
+            application/vnd.oci.image.index.v1+json|application/vnd.docker.distribution.manifest.list.v2+json)
+              architecture="${PLATFORM#linux/}"
+              package_manifest_digest="$(jq -er --arg architecture "$architecture" \
+                '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture)] | if length == 1 then .[0].digest else error("expected exactly one runnable platform manifest") end' \
+                "$RUNNER_TEMP/platform-candidate-descriptor.json")"
+              ;;
+            *)
+              echo "unsupported platform candidate media type: $media_type" >&2
+              exit 1
+              ;;
+          esac
           [[ "$package_manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
-          jq -n --arg platform "$PLATFORM" --arg slug "$PLATFORM_SLUG" --arg digest "$package_manifest_digest" --arg candidateIndexDigest "$CANDIDATE_INDEX_DIGEST" --arg runner "$RUNNER_VERSION" --arg runnerDigest "$RUNNER_DIGEST" \
-            '{platform:$platform,slug:$slug,packageManifestDigest:$digest,candidateIndexDigest:$candidateIndexDigest,runnerVersion:$runner,runnerAssetDigest:$runnerDigest}' > "$RUNNER_TEMP/platform-result.json"
+          jq -n --arg platform "$PLATFORM" --arg slug "$PLATFORM_SLUG" --arg digest "$package_manifest_digest" --arg candidateDescriptorDigest "$CANDIDATE_DESCRIPTOR_DIGEST" --arg runner "$RUNNER_VERSION" --arg runnerDigest "$RUNNER_DIGEST" \
+            '{platform:$platform,slug:$slug,packageManifestDigest:$digest,candidateDescriptorDigest:$candidateDescriptorDigest,runnerVersion:$runner,runnerAssetDigest:$runnerDigest}' > "$RUNNER_TEMP/platform-result.json"
 
       - name: Upload platform digest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -551,13 +603,13 @@ jobs:
           [[ "$arm64_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
           staging_ref="${PACKAGE_REPOSITORY}:candidate-${PROFILE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           docker buildx imagetools create --tag "$staging_ref" \
-            "${PACKAGE_REPOSITORY}:candidate-${PROFILE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-            "${PACKAGE_REPOSITORY}:candidate-${PROFILE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+            "${PACKAGE_REPOSITORY}@${amd64_digest}" \
+            "${PACKAGE_REPOSITORY}@${arm64_digest}"
           index_digest="$(oras resolve "$staging_ref")"
           [[ "$index_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
           oras manifest fetch "$staging_ref" --format json > "$RUNNER_TEMP/epar-index.json"
           jq -e --arg amd64 "$amd64_digest" --arg arm64 "$arm64_digest" \
-            '[((.content.manifests // .manifests)[]) | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"))] | length == 2 and (map(.platform.architecture) | sort == ["amd64","arm64"]) and (map(.digest) | sort == ([$amd64,$arm64] | sort))' "$RUNNER_TEMP/epar-index.json" >/dev/null
+            '[(.content.manifests // .manifests)[]] as $manifests | ($manifests | length) == 2 and ($manifests | map(select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"))) | length) == 2 and ($manifests | map(.platform.architecture) | sort == ["amd64","arm64"]) and ($manifests | map(.digest) | sort == ([$amd64,$arm64] | sort))' "$RUNNER_TEMP/epar-index.json" >/dev/null
           current_source_digest="$(oras resolve "$SOURCE_REFERENCE")"
           [[ "$current_source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
           source_rechecked=true

--- a/cmd/epar-prebuilt-publisher/workflow_contract_test.go
+++ b/cmd/epar-prebuilt-publisher/workflow_contract_test.go
@@ -70,6 +70,31 @@ func TestWorkflowUsesHostedBuildsAndExternalEPARAcceptance(t *testing.T) {
 	}
 }
 
+func TestWorkflowPublishesOnlyFromMainAndValidatesPullRequestsWithoutPublishing(t *testing.T) {
+	workflow := strings.ReplaceAll(readPublisherWorkflow(t), "\r\n", "\n")
+	for _, required := range []string{
+		"push:\n    branches:\n      - main",
+		"pull_request:\n    branches:\n      - develop\n      - main",
+		"name: Validate prebuilt publication contract without publishing",
+		"if: github.event_name == 'pull_request'",
+		"permissions:\n      contents: read",
+		"go test ./internal/prebuilt ./cmd/epar-prebuilt-publisher -count=1",
+		"if: github.event_name != 'pull_request' && inputs.promote_candidate != true",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("workflow branch/publication isolation is missing %q", required)
+		}
+	}
+	pushStart := strings.Index(workflow, "  push:\n")
+	pullRequestStart := strings.Index(workflow, "  pull_request:\n")
+	if pushStart < 0 || pullRequestStart < 0 || pushStart >= pullRequestStart {
+		t.Fatalf("cannot isolate push trigger: push=%d pull_request=%d", pushStart, pullRequestStart)
+	}
+	if strings.Contains(workflow[pushStart:pullRequestStart], "      - develop\n") {
+		t.Fatal("develop pushes must not publish GHCR candidates")
+	}
+}
+
 func TestWorkflowPublicationCannotMutateGitOrSourceReleaseState(t *testing.T) {
 	workflow := strings.ReplaceAll(readPublisherWorkflow(t), "\r\n", "\n")
 	if !strings.Contains(workflow, "permissions:\n  contents: read") {
@@ -90,17 +115,34 @@ func TestWorkflowAllowsAbsoluteCatalogPathsForORASPush(t *testing.T) {
 	}
 }
 
-func TestWorkflowRecordsRunnablePlatformManifestFromAttestedCandidateIndex(t *testing.T) {
+func TestWorkflowRecordsRunnablePlatformManifestWithoutDuplicatePlatformEvidence(t *testing.T) {
 	workflow := readPublisherWorkflow(t)
 	for _, required := range []string{
-		`docker buildx imagetools inspect "$CANDIDATE_REFERENCE" --raw`,
+		`platform_candidate_ref="${PACKAGE_REPOSITORY}@${CANDIDATE_DESCRIPTOR_DIGEST}"`,
+		`docker buildx imagetools inspect "$platform_candidate_ref" --raw`,
+		`provenance: false`,
+		`sbom: false`,
+		`application/vnd.oci.image.manifest.v1+json|application/vnd.docker.distribution.manifest.v2+json`,
+		`package_manifest_digest="$CANDIDATE_DESCRIPTOR_DIGEST"`,
 		`select(.platform.os == "linux" and .platform.architecture == $architecture)`,
 		`if length == 1 then .[0].digest else error("expected exactly one runnable platform manifest") end`,
-		`packageManifestDigest:$digest,candidateIndexDigest:$candidateIndexDigest`,
+		`packageManifestDigest:$digest,candidateDescriptorDigest:$candidateDescriptorDigest`,
+		`"${PACKAGE_REPOSITORY}@${amd64_digest}"`,
+		`"${PACKAGE_REPOSITORY}@${arm64_digest}"`,
+		`($manifests | length) == 2`,
 	} {
 		if !strings.Contains(workflow, required) {
-			t.Fatalf("workflow no longer records an exact runnable platform manifest from the attested candidate index: missing %q", required)
+			t.Fatalf("workflow no longer records an exact runnable platform manifest without duplicate platform evidence: missing %q", required)
 		}
+	}
+	if strings.Contains(workflow, "provenance: mode=max") || strings.Contains(workflow, "sbom: true") {
+		t.Fatal("platform builds must not recreate evidence already signed for the completed multi-platform index")
+	}
+	if got := strings.Count(workflow, "Generate signed index SLSA referrer"); got != 1 {
+		t.Fatalf("completed package index must retain exactly one signed SLSA referrer step: got %d", got)
+	}
+	if got := strings.Count(workflow, "Generate signed index SPDX SBOM referrer"); got != 1 {
+		t.Fatalf("completed package index must retain exactly one signed SPDX referrer step: got %d", got)
 	}
 }
 

--- a/docs/development/docker-sandboxes-prebuilt.md
+++ b/docs/development/docker-sandboxes-prebuilt.md
@@ -8,11 +8,11 @@ Act (`act-latest`) is the initial supported profile. Full (`full-latest`) remain
 
 ## Workflow triggers and hosted build gates
 
-`.github/workflows/docker-sandboxes-images.yml` polls every six hours at minute 37, supports manual dispatch, and runs for recipe-related changes on configured branches. GitHub executes the cron only from the default branch, so the same workflow file existing on `develop` does not create a second scheduled run. Feature branches do not publish packages unless an explicit temporary trigger is deliberately added for an isolated pilot.
+`.github/workflows/docker-sandboxes-images.yml` polls every six hours at minute 37, supports manual dispatch, and publishes for recipe-related pushes only on `main`. GitHub executes the cron only from the default branch. Pull requests to `develop` or `main` that change a publisher, recipe, or committed-asset path run publisher, signed-evidence, and asset validation without logging in to GHCR, building a package, or pushing any manifest. This prevents a normal `develop` to `main` promotion from publishing the same source change twice.
 
-The amd64 build runs on GitHub-hosted `ubuntu-latest`; the arm64 build runs on GitHub-hosted `ubuntu-24.04-arm`. The workflow has no persistent self-hosted runner dependency and no `EPAR_PREBUILT_LIVE` switch. Hosted jobs resolve the GHCR source descriptor, build from its immutable digest, inspect both platform images, assemble the exact two-platform index, run package smoke checks, generate SLSA/SPDX evidence, verify referrers, and publish an immutable signed candidate catalog.
+The amd64 build runs on GitHub-hosted `ubuntu-latest`; the arm64 build runs on GitHub-hosted `ubuntu-24.04-arm`. The workflow has no persistent self-hosted runner dependency and no `EPAR_PREBUILT_LIVE` switch. Hosted jobs resolve the GHCR source descriptor, build from its immutable digest, inspect both runnable platform manifests by digest, assemble an index from those exact digests, require exactly two descriptors, run package smoke checks, generate and sign one index-level SLSA provenance statement and one index-level SPDX SBOM, verify their referrers, and publish an immutable signed candidate catalog. Platform builds disable BuildKit's additional per-platform SBOM/provenance indexes because EPAR's trust decision uses the separately signed index-level evidence and catalog. The index-level SPDX document records the package, recipe, and exact platform identities rather than reproducing BuildKit's more detailed component inventory; this deliberate narrower audit scope avoids four additional per-publication GHCR version rows without weakening the evidence enforced by EPAR.
 
-The workflow grants `contents: read`, `packages: write`, `attestations: write`, and `id-token: write`. Third-party actions are pinned to full commit SHAs. Publication is serialized by one non-cancelling concurrency group.
+The workflow grants `contents: read`, `packages: write`, `attestations: write`, and `id-token: write` to publication jobs, while pull-request validation overrides permissions to `contents: read`. Third-party actions are pinned to full commit SHAs. Publication is serialized by one non-cancelling concurrency group; validation uses one group per pull request and cancels only a superseded validation run for that same pull request.
 
 ## Candidate publication contract
 
@@ -24,6 +24,10 @@ Every new package is first recorded as `candidate`. Before manual acceptance, pu
 - an immutable catalog object and canonical tag such as `catalog-v1-pkg-<64 hex catalog digest>`.
 
 Candidate publication does not move `catalog-v1` or `act-latest`. This permits first-catalog bootstrap: a candidate can be acquired through its exact signed immutable catalog even when no moving catalog exists yet.
+
+### GHCR version graph
+
+GitHub Packages displays every OCI manifest as a package version, so one logical candidate appears as several rows. The expected retained graph contains the final multi-platform package index, its amd64 and arm64 runnable manifests, signed SLSA and SPDX referrer manifests and their discovery index, the immutable catalog manifest, and the catalog signature and discovery index. Tags named `act-latest-pkg-<digest>` and `catalog-v1-pkg-<digest>` are write-once audit identities. Run-specific `candidate-<profile>-<run>-<attempt>` tags are staging and diagnostic aliases, while `sha256-<subject digest>` tags are attestation-discovery indexes used by the verifier; neither is an end-user image channel. An untagged child manifest can still be required by a retained index and must not be deleted merely because the GitHub Packages page calls it untagged.
 
 Production builds always use the resolved immutable upstream digest. The upstream tag is re-resolved before publication. If it moves during the build, the package remains an immutable candidate and no moving alias advances.
 
@@ -78,7 +82,7 @@ provider:
 
 For the Mac config, change `sourcePlatform` and `provider.platform` to `linux/arm64`, use a distinct `pool.namePrefix`, and change the unique label suffix to `-arm64`. The organization runner group `epar-dev-test` must allow only `solutionforest/ephemeral-action-runner-test` and must not allow public repositories. The host machines run EPAR normally; they are not registered directly as persistent GitHub Actions runners.
 
-Run `./start image build --config <candidate-config>` first. Successful acquisition verifies the immutable catalog and package evidence, materializes/imports the selected platform, performs exact `sbx template ls` readback, and writes `.local/state/image/<config-id>/docker-sandboxes/active.json`. A missing, mismatched, unsigned, revoked, or wrong-ref candidate fails closed without a local Catthehacker build or provider fallback.
+Run `./start --config <candidate-config>` to provision and start the temporary acceptance pool; it automatically performs the required image acquisition before creating a Sandbox. An explicit `./start image build --config <candidate-config>` is optional when an operator wants to provision and inspect the template without starting the pool. Successful acquisition verifies the immutable catalog and package evidence, materializes/imports the selected platform, performs exact `sbx template ls` readback, and writes `.local/state/image/<config-id>/docker-sandboxes/active.json`. A missing, mismatched, unsigned, revoked, or wrong-ref candidate fails closed without a local Catthehacker build or provider fallback.
 
 ## Four-run acceptance suite
 
@@ -132,6 +136,6 @@ go run ./cmd/epar-prebuilt-publisher verify-package --reference ghcr.io/solution
 
 ## Retention and revocation
 
-Immutable package and catalog objects are retained for audit and rollback. The workflow performs no broad deletion. Revocation appends `revoked` or `critical-revoked` status to a newly signed catalog; it does not delete the immutable package. Candidate acquisition rejects a revoked status in its exact signed catalog. Normal stable consumers enforce the current signed moving-catalog status, with `critical-revoked` blocking new Sandbox admissions.
+Immutable accepted, active, superseded rollback, and revoked package and catalog objects are retained for audit and recovery. The workflow performs no broad deletion. Unaccepted CI candidates may be removed only by future reachability-aware maintenance after a documented retention window; that maintenance must preserve every object referenced by a retained package index, attestation-discovery index, signed catalog, active receipt, or rollback identity. Manual deletion of individual untagged GitHub Packages rows is unsafe. Revocation appends `revoked` or `critical-revoked` status to a newly signed catalog; it does not delete the immutable package. Candidate acquisition rejects a revoked status in its exact signed catalog. Normal stable consumers enforce the current signed moving-catalog status, with `critical-revoked` blocking new Sandbox admissions.
 
 The public base contains no workstation CA, enterprise credential, proxy endpoint, `NO_PROXY`, forward-bypass configuration, pool data, or custom install script. Host trust is a runtime overlay. Custom scripts create a local derivative from the already verified package digest and use BuildKit secret mounts for private build trust; no script or CA change silently redownloads the unchanged public base.


### PR DESCRIPTION
## Summary

- Publish Docker Sandboxes package candidates only from `main`, while pull requests run read-only publisher and asset validation.
- Assemble the final multi-platform image from exact platform digests and require exactly two descriptors.
- Keep signed index-level SLSA/SPDX and catalog evidence while removing redundant BuildKit per-platform attestation wrappers.
- Document the GHCR version graph, retention boundaries, and automatic image provisioning through `./start`.

## Validation

- `go test ./internal/prebuilt ./cmd/epar-prebuilt-publisher -count=1`
- `go test -race ./internal/prebuilt ./cmd/epar-prebuilt-publisher -count=1`
- `go test ./... -run '^$' -count=1`
- `scripts/docker-sandboxes/validate-assets.ps1 -Platform linux/amd64`
- `scripts/docker-sandboxes/validate-assets.ps1 -Platform linux/arm64`
- `actionlint .github/workflows/docker-sandboxes-images.yml`
- `git diff --check`

## Checklist

- [x] I kept credentials, private keys, tokens, and machine-specific configuration out of this pull request.
- [x] I added or updated tests where behavior changed.
- [x] I updated relevant documentation.
- [x] For provider or onboarding changes, I followed the Development and Extension Principles and documented and tested every intentional exception.
- [x] I read and followed the contributing guide and code of conduct.