### PR TITLE
Fix prebuilt catalog manifest readback

### DIFF
--- a/.github/scripts/fetch-prebuilt-catalog.sh
+++ b/.github/scripts/fetch-prebuilt-catalog.sh
@@ -44,7 +44,7 @@ trap cleanup EXIT
 
 manifest_file="$work_directory/manifest.json"
 catalog_file="$work_directory/catalog.json"
-oras manifest fetch "$reference" --format json > "$manifest_file"
+oras manifest fetch "$reference" > "$manifest_file"
 
 layer_digest="$({
   jq -er \
@@ -54,10 +54,10 @@ layer_digest="$({
     'select(.schemaVersion == 2)
      | select(.mediaType == "application/vnd.oci.image.manifest.v1+json")
      | select(.artifactType == $artifact)
-     | select(.content.config.mediaType == $config)
-     | select((.content.layers | length) == 1)
-     | select(.content.layers[0].mediaType == $layer)
-     | .content.layers[0].digest
+     | select(.config.mediaType == $config)
+     | select((.layers | length) == 1)
+     | select(.layers[0].mediaType == $layer)
+     | .layers[0].digest
      | select(test("^sha256:[0-9a-f]{64}$"))' \
     "$manifest_file"
 } || true)"

--- a/.github/workflows/docker-sandboxes-images.yml
+++ b/.github/workflows/docker-sandboxes-images.yml
@@ -1032,8 +1032,8 @@ jobs:
             existing_manifest="$(oras resolve "$immutable_ref")"
           fi
           [[ "$existing_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]
-          oras manifest fetch "$immutable_ref" --format json > "$RUNNER_TEMP/epar-promotion/catalog-manifest.json"
-          jq -e --arg artifact "$CATALOG_ARTIFACT_TYPE" --arg config "$CATALOG_CONFIG_MEDIA_TYPE" --arg layer "$CATALOG_LAYER_MEDIA_TYPE" '(.schemaVersion == 2) and (.mediaType == "application/vnd.oci.image.manifest.v1+json") and (.artifactType == $artifact) and (.content.config.mediaType == $config) and ((.content.layers | length) == 1) and (.content.layers[0].mediaType == $layer)' "$RUNNER_TEMP/epar-promotion/catalog-manifest.json" >/dev/null
+          oras manifest fetch "$immutable_ref" > "$RUNNER_TEMP/epar-promotion/catalog-manifest.json"
+          jq -e --arg artifact "$CATALOG_ARTIFACT_TYPE" --arg config "$CATALOG_CONFIG_MEDIA_TYPE" --arg layer "$CATALOG_LAYER_MEDIA_TYPE" '(.schemaVersion == 2) and (.mediaType == "application/vnd.oci.image.manifest.v1+json") and (.artifactType == $artifact) and (.config.mediaType == $config) and ((.layers | length) == 1) and (.layers[0].mediaType == $layer)' "$RUNNER_TEMP/epar-promotion/catalog-manifest.json" >/dev/null
           echo "catalog_digest=$catalog_digest" >> "$GITHUB_OUTPUT"
           echo "manifest_digest=$existing_manifest" >> "$GITHUB_OUTPUT"
           echo "immutable_ref=$immutable_ref" >> "$GITHUB_OUTPUT"
@@ -1433,8 +1433,8 @@ jobs:
             existing_manifest="$(oras resolve "$immutable_ref")"
           fi
           [[ "$existing_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]
-          oras manifest fetch "$immutable_ref" --format json > "$RUNNER_TEMP/manual-catalog-manifest.json"
-          jq -e --arg artifact "$CATALOG_ARTIFACT_TYPE" --arg config "$CATALOG_CONFIG_MEDIA_TYPE" --arg layer "$CATALOG_LAYER_MEDIA_TYPE" '(.schemaVersion == 2) and (.mediaType == "application/vnd.oci.image.manifest.v1+json") and (.artifactType == $artifact) and (.content.config.mediaType == $config) and ((.content.layers | length) == 1) and (.content.layers[0].mediaType == $layer)' "$RUNNER_TEMP/manual-catalog-manifest.json" >/dev/null
+          oras manifest fetch "$immutable_ref" > "$RUNNER_TEMP/manual-catalog-manifest.json"
+          jq -e --arg artifact "$CATALOG_ARTIFACT_TYPE" --arg config "$CATALOG_CONFIG_MEDIA_TYPE" --arg layer "$CATALOG_LAYER_MEDIA_TYPE" '(.schemaVersion == 2) and (.mediaType == "application/vnd.oci.image.manifest.v1+json") and (.artifactType == $artifact) and (.config.mediaType == $config) and ((.layers | length) == 1) and (.layers[0].mediaType == $layer)' "$RUNNER_TEMP/manual-catalog-manifest.json" >/dev/null
           echo "catalog_digest=$catalog_digest" >> "$GITHUB_OUTPUT"
           echo "manifest_digest=$existing_manifest" >> "$GITHUB_OUTPUT"
           echo "immutable_ref=$immutable_ref" >> "$GITHUB_OUTPUT"

--- a/cmd/epar-prebuilt-publisher/workflow_contract_test.go
+++ b/cmd/epar-prebuilt-publisher/workflow_contract_test.go
@@ -135,15 +135,26 @@ func TestWorkflowFetchesCatalogsByValidatedDescriptorAndPublishesSafeRelativeTit
 	if got := strings.Count(workflow, `oras push "$immutable_ref"`); got != 2 {
 		t.Fatalf("automatic and manual catalog publication must retain exactly two guarded pushes: got %d", got)
 	}
+	if got := strings.Count(workflow, `oras manifest fetch "$immutable_ref" >`); got != 2 {
+		t.Fatalf("automatic and manual catalog readback must inspect two raw OCI manifests: got %d", got)
+	}
+	if strings.Contains(workflow, `oras manifest fetch "$immutable_ref" --format json`) {
+		t.Fatal("catalog readback must not confuse ORAS formatted metadata with the raw OCI manifest")
+	}
+	for _, required := range []string{`(.config.mediaType == $config)`, `((.layers | length) == 1)`, `(.layers[0].mediaType == $layer)`} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("catalog raw-manifest readback is missing %q", required)
+		}
+	}
 }
 
 func TestCatalogFetcherRejectsLayerPathsAndValidatesExactBlob(t *testing.T) {
 	script := readCatalogFetchScript(t)
 	for _, required := range []string{
-		`oras manifest fetch "$reference" --format json`,
+		`oras manifest fetch "$reference" > "$manifest_file"`,
 		`catalog reference must be an exact digest`,
 		`select(.artifactType == $artifact)`,
-		`select((.content.layers | length) == 1)`,
+		`select((.layers | length) == 1)`,
 		`oras blob fetch --output "$catalog_file" "${repository}@${layer_digest}"`,
 		`actual_digest="sha256:$(sha256sum "$catalog_file"`,
 		`(.schemaVersion == 1) and (.artifactKind == "docker-sandboxes-template")`,
@@ -156,6 +167,9 @@ func TestCatalogFetcherRejectsLayerPathsAndValidatesExactBlob(t *testing.T) {
 		if strings.Contains(script, forbidden) {
 			t.Fatalf("catalog fetcher contains unsafe path behavior %q", forbidden)
 		}
+	}
+	if strings.Contains(script, "--format json") {
+		t.Fatal("catalog fetcher must validate the raw OCI manifest rather than ORAS formatted metadata")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix the main publisher failure in run 31452336414 after its immutable catalog push succeeded.
- Read ORAS catalog manifests in raw OCI form for both collision checks and post-push readback.
- Validate the stable top-level OCI config/layer descriptor shape instead of mixing it with ORAS formatted metadata.
- Preserve the descriptor-addressed catalog blob fetch and the pre-approval promotion review summary added by PR #23.

The failed run created a correctly formed immutable catalog with a safe relative layer title, but stopped before signing it or moving any stable alias.

## Validation

- actionlint .github/workflows/docker-sandboxes-images.yml
- bash -n .github/scripts/fetch-prebuilt-catalog.sh
- go test ./internal/prebuilt ./cmd/epar-prebuilt-publisher -count=1
- git diff --check
- Public readback of catalog-v1-pkg-7e95e98ffecebd30af369dfbf02b4bdfa8d5a91eb7c8927a6109ddc733868791 confirmed the expected OCI manifest/config/single-layer shape and relative catalog.json title.

## Checklist

- [x] I kept credentials, private keys, tokens, and machine-specific configuration out of this pull request.
- [x] I added or updated tests where behavior changed.
- [x] No stable package or catalog alias is moved by pull-request validation.
- [x] I read and followed the contributing guide.