### PR TITLE
Prepare v0.3.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ A provider or onboarding change is incomplete until its wizard and generated con
 
 ## Agent-created temporary files
 
-Do not create ad hoc top-level directories under `.local`. All scratch files, temporary build output, one-off test state, and agent-specific caches created while investigating, implementing, or validating work must live under `.local/tmp/`, grouped beneath a descriptive task or tool directory such as `.local/tmp/codex/<task-name>/`. This includes manually assigned `GOCACHE`, `GOTMPDIR`, `GOMODCACHE`, test state roots, downloaded diagnostic tools, generated fixtures, and transient command output.
+Do not create ad hoc top-level directories under `.local`. All scratch files, temporary build output, one-off test state, and agent-specific caches created while investigating, implementing, or validating work must live under `.local/tmp/`, grouped beneath a descriptive task or tool directory such as `.local/tmp/<agent-name>/<task-name>/`. This includes manually assigned `GOCACHE`, `GOTMPDIR`, `GOMODCACHE`, test state roots, downloaded diagnostic tools, generated fixtures, and transient command output.
 
 Do not place agent-created temporary content in the product-owned `.local/bin`, `.local/cache`, `.local/state`, or `.local/storage` trees unless the product code being exercised creates that exact documented path as part of its normal behavior. Never introduce another top-level `.local/<tool-name>` or `.local/<purpose>` directory for convenience. Prefer the operating system temporary directory when the artifact does not need to remain with the checkout.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 EPAR keeps a warm pool of disposable GitHub Actions runners. Each runner handles one job inside a dedicated [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) microVM with a private Docker daemon, then is replaced with a clean runner.
 
+**EPAR is for teams that want to use their own compute for CI without running GitHub Actions jobs directly on the host.**
+
 ![Ephemeral Action Runner banner](docs/assets/brand/epar-banner.jpg)
 
 ```mermaid
@@ -14,13 +16,17 @@ flowchart LR
 
 ## Why EPAR
 
-- Keep private-repository CI ready without maintaining a long-lived runner workspace.
-- Recycle the runner, its private daemon, and job state after every job.
-- Run Docker-based Linux jobs from Linux, macOS, or Windows hosts when Docker Sandboxes capability checks pass.
+- **Put spare compute to work** — run long-running E2E, integration, and Docker-heavy CI on machines you already operate.
+- **Add a strong isolation boundary around CI jobs** — each Docker Sandboxes runner runs inside a dedicated microVM rather than directly on the host.
+- **Keep Docker private to the runner** — Docker workloads use the sandbox's private daemon instead of the host Docker socket.
+- **Start clean after every job** — destroy the runner, private daemon, filesystem, and job state, then replace them with a fresh runner.
+- **Stay warm without keeping runner state around** — maintain ready-to-accept runners while preserving the one-runner, one-job lifecycle.
+- **Keep the infrastructure small** — run from Linux, macOS, or Windows hosts without introducing a separate cluster or orchestration platform just to manage CI runners.
 
 ## Quick Start
 
-This quick start uses Docker Sandboxes. Install Docker and the Docker Sandboxes `sbx` CLI, then confirm that `sbx diagnose --output json` reports at least one passing check and no failures. EPAR keeps the detailed helper, proxy, and build guidance in the linked deep guides.
+This quick start uses Docker Sandboxes. Install Docker and the [Docker Sandboxes `sbx` CLI](https://docs.docker.com/ai/sandboxes/).
+Make sure you ran `sbx` once, which will have a wizard to guide on first time setup for Docker Sandboxes (e.g. login), then run `sbx diagnose` to confirm all passes, no failures.
 
 1. Download GitHub's **Source code (zip)** or **Source code (tar.gz)** for the release you want from the [EPAR releases page](https://github.com/solutionforest/ephemeral-action-runner/releases), extract it, and open a terminal in the extracted folder.
 2. Create a GitHub App by following [GitHub App Setup](docs/github-app.md); have the App ID, organization name, and private-key file path ready.
@@ -30,14 +36,14 @@ This quick start uses Docker Sandboxes. Install Docker and the Docker Sandboxes 
    ./start
    ```
 
-The first run opens a guided setup wizard for the GitHub App, runner group, Docker Sandboxes host checks, and runner image. Keep the process open while runners should accept work. Press `Ctrl-C` once to stop and wait for cleanup to finish before closing the terminal. See [Usage](docs/usage.md) for configuration, verification, no-Go startup, and cleanup details.
+The first run opens a guided setup wizard for the GitHub App, runner group, Docker Sandboxes host checks, and runner image. Just follow the wizard to setup and start EPAR. Keep the process open while runners should accept work. Press `Ctrl-C` once to stop and wait for cleanup to finish before closing the terminal. See [Usage](docs/usage.md) for configuration, verification, no-Go startup, and cleanup details.
 
 ## Route a workflow to EPAR
 
 Every EPAR runner has GitHub's `self-hosted` label. Add the EPAR Sandboxes label when a workflow should use this environment:
 
 ```yaml
-runs-on: [self-hosted, linux, epar-docker-sandboxes]
+runs-on: [self-hosted, linux]
 ```
 
 Use labels that describe the environment your job needs and keep runner groups limited to the repositories and secrets that require access.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,6 +5,7 @@ Start with the symptom that most closely matches the failure. Regardless of prov
 ## Contents
 
 - [Quick diagnostics](#quick-diagnostics)
+- [Startup reports that the pool controller configuration lock is already held](#startup-reports-that-the-pool-controller-configuration-lock-is-already-held)
 - [Windows no-Go startup prints an HTTP/2 named-pipe diagnostic](#windows-no-go-startup-prints-an-http2-named-pipe-diagnostic)
 - [A Docker workload fails with an architecture error](#a-docker-workload-fails-with-an-architecture-error)
 - [Docker Sandboxes is unavailable or its preflight fails](#docker-sandboxes-is-unavailable-or-its-preflight-fails)
@@ -48,6 +49,42 @@ docker run --rm ghcr.io/catthehacker/ubuntu:full-latest df -h /
 ```
 
 Container-visible free space is the relevant value for Docker builds. Windows Explorer or Finder free space does not necessarily equal the free space in a Linux VM backing the daemon.
+
+## Startup reports that the pool controller configuration lock is already held
+
+### Symptom
+
+`./start` exits with an error like:
+
+```text
+ephemeral-action-runner: pool controller configuration lock is already held for "/Users/someone/epar/.local/config.yml" (owner config="/Users/someone/epar/.local/config.yml" provider="docker-sandboxes" prefix="example-pool" pid=12345 startedAt=2026-01-02T03:04:05Z)
+```
+
+This can appear after the startup wrapper rebuilds the native controller because its source digest changed. The rebuild prepares a new binary but does not replace an already-running controller, so the new process still stops at the ownership lock.
+
+### Diagnosis and remediation
+
+The lock prevents two mutating controllers from managing the same pool. Treat the reported config path, provider, prefix, PID, and start time as owner-identification evidence rather than deleting a lock file.
+
+On macOS or Linux, inspect the reported PID, replacing `12345` with the value from the error:
+
+```bash
+ps -p 12345 -o pid=,ppid=,lstart=,command=
+```
+
+On Windows PowerShell:
+
+```powershell
+Get-Process -Id 12345 -ErrorAction SilentlyContinue | Format-List Id, StartTime, Path
+```
+
+If the PID is the intended live EPAR controller, do not start another controller for that pool. Return to its terminal and press Ctrl-C once, or stop it through the service manager that launched it, then wait for `Cleanup complete. EPAR can now exit safely.` before running `./start` again. Use this sequence when activating copied source or a rebuilt controller: stop the old controller cleanly, wait for cleanup, then start the new version.
+
+If no process owns the reported PID, rerun `./start`. The operating-system lock is authoritative and is released when its owning process exits; stale descriptive metadata may remain on disk but is replaced on the next successful acquisition. Do not manually delete files under the controller-lock state directory, and do not signal a process solely because its PID matches stale metadata—PID values can be reused.
+
+If the exact EPAR controller is unresponsive, prefer its service manager's graceful stop or a single interrupt and allow time for cleanup. After a confirmed abnormal exit, rerun `./start` so normal lifecycle reconciliation can inspect and recover exact owned resources. Avoid force-killing the process, deleting runner records manually, or using broad Docker, Sandbox, WSL, or GitHub cleanup commands as a first response.
+
+Multiple EPAR controllers may run on one machine, but every concurrently active controller must use both a distinct canonical configuration path and a distinct normalized `pool.namePrefix`. Reusing either the same config path or the same pool prefix intentionally conflicts, including across different project directories or providers. Give each controller its own config and pool identity instead of bypassing the lock.
 
 ## Windows no-Go startup prints an HTTP/2 named-pipe diagnostic
 
@@ -182,7 +219,7 @@ EPAR does not query or mutate host-global `sbx` secrets. After creating its exac
 
 ## An idle runner reports GitHub or Sandbox health warnings
 
-A GitHub 429/5xx response or an `sbx` command timeout makes runner health temporarily unknown; it does not prove that the Actions listener stopped. EPAR keeps the exact runner, lets a trust lease expire closed when it cannot refresh it, and retries. Cleanup for an inactive listener requires two consecutive guest probes that successfully execute and explicitly report the process stopped. Review the instance guest transcript when warnings repeat; do not delete the runner merely because one API or Sandbox inspection failed.
+A GitHub 429/5xx response or an `sbx` command timeout makes runner health temporarily unknown; it does not prove that the Actions listener stopped. EPAR preserves uncertain local capacity, but a runner whose host-trust transport or lease cannot be maintained is quarantined and its exact GitHub registration is fenced after immutable name-and-ID verification so it cannot accept new work with an expired lease. Cleanup for an inactive listener requires two consecutive guest probes that successfully execute and explicitly report the process stopped. Review the instance guest transcript when warnings repeat; do not delete the runner merely because one API or Sandbox inspection failed.
 
 `networkBaseline: open` is a sandbox-scoped public-egress compatibility rule with EPAR host-alias deny guardrails. It does not alter the host-global policy. If a required service is blocked, use a narrow `additionalAllow` hostname rule; do not allow `host.docker.internal`, `gateway.docker.internal`, `kubernetes.docker.internal`, or `host.containers.internal` through the Open-policy guardrails.
 

--- a/internal/pool/host_trust.go
+++ b/internal/pool/host_trust.go
@@ -470,6 +470,32 @@ func (m *Manager) revokeHostTrustLease(ctx context.Context, instanceName string)
 	return err
 }
 
+func (m *Manager) fenceHostTrustRunnerRegistration(ctx context.Context, instance ProvisionedInstance, cause error) error {
+	// Admission uncertainty must be durable even when the exact remote fence
+	// cannot be completed. The physical instance remains capacity-counting and
+	// reconciliation must not advertise it as Ready again by name alone.
+	fenceCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostTrustWriteTimeout)
+	defer cancel()
+	m.quarantineLifecycle(fenceCtx, instance.Name, cause)
+	if m.GitHub == nil || instance.RunnerID == 0 {
+		return fmt.Errorf("exact GitHub runner identity is unavailable; cannot fence registration")
+	}
+	runner, found, err := m.GitHub.RunnerByName(fenceCtx, instance.Name)
+	if err != nil {
+		return fmt.Errorf("verify exact GitHub runner before host-trust fence: %w", err)
+	}
+	if !found {
+		return nil
+	}
+	if runner.ID != instance.RunnerID {
+		return fmt.Errorf("same-name GitHub runner id=%d does not match expected id=%d; refusing registration fence", runner.ID, instance.RunnerID)
+	}
+	if err := m.GitHub.DeleteRunnerIfExists(fenceCtx, runner.ID); err != nil {
+		return fmt.Errorf("delete exact GitHub runner id=%d: %w", instance.RunnerID, err)
+	}
+	return nil
+}
+
 func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[string]ProvisionedInstance, current hosttrust.Snapshot, busyHandoff map[string]bool) int {
 	if m.GitHub == nil {
 		return 0
@@ -487,23 +513,21 @@ func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[stri
 		if _, requiresTransport := m.providerLifecycle().(provider.HostTrustRuntimeActivator); requiresTransport {
 			providerInstance, providerErr := m.providerInstance(ctx, name)
 			if providerErr != nil {
-				revokeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostTrustWriteTimeout)
-				revokeErr := m.revokeHostTrustLease(revokeCtx, name)
-				cancel()
 				m.warnf("[%s] host trust transport identity warning; lease not refreshed: %v\n", name, providerErr)
-				if revokeErr != nil {
-					m.warnf("[%s] host trust transport identity fencing warning: %v\n", name, revokeErr)
+				if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, providerErr); fenceErr != nil {
+					m.warnf("[%s] host trust registration fencing warning: %v\n", name, fenceErr)
 				}
+				instance.Phase = LifecycleQuarantined
+				active[name] = instance
 				continue
 			}
 			if err := m.activateProviderHostTrustRuntime(ctx, providerInstance); err != nil {
-				revokeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostTrustWriteTimeout)
-				revokeErr := m.revokeHostTrustLease(revokeCtx, name)
-				cancel()
 				m.warnf("[%s] host trust transport refresh warning; lease not refreshed: %v\n", name, err)
-				if revokeErr != nil {
-					m.warnf("[%s] host trust transport refresh fencing warning: %v\n", name, revokeErr)
+				if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, err); fenceErr != nil {
+					m.warnf("[%s] host trust registration fencing warning: %v\n", name, fenceErr)
 				}
+				instance.Phase = LifecycleQuarantined
+				active[name] = instance
 				continue
 			}
 		}
@@ -513,6 +537,12 @@ func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[stri
 			// the assignment window even when GitHub status is unavailable.
 			if err := m.issueHostTrustLease(ctx, name, current); err != nil {
 				m.warnf("[%s] old-generation revocation warning: %v\n", name, err)
+				if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, err); fenceErr != nil {
+					m.warnf("[%s] host trust registration fencing warning: %v\n", name, fenceErr)
+				}
+				instance.Phase = LifecycleQuarantined
+				active[name] = instance
+				continue
 			}
 		}
 		runner, found, err := m.GitHub.RunnerByName(ctx, name)
@@ -538,6 +568,11 @@ func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[stri
 				// renew it while the job remains busy.
 				if err := m.issueHostTrustLeaseWithLifetime(ctx, name, current, hostTrustHandoffLease); err != nil {
 					m.warnf("[%s] host trust job handoff lease warning: %v\n", name, err)
+					if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, err); fenceErr != nil {
+						m.warnf("[%s] host trust registration fencing warning: %v\n", name, fenceErr)
+					}
+					instance.Phase = LifecycleQuarantined
+					active[name] = instance
 					continue
 				}
 				busyHandoff[name] = true
@@ -546,6 +581,11 @@ func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[stri
 			delete(busyHandoff, name)
 			if err := m.issueHostTrustLease(ctx, name, current); err != nil {
 				m.warnf("[%s] host trust lease refresh warning: %v\n", name, err)
+				if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, err); fenceErr != nil {
+					m.warnf("[%s] host trust registration fencing warning: %v\n", name, fenceErr)
+				}
+				instance.Phase = LifecycleQuarantined
+				active[name] = instance
 			}
 			continue
 		}
@@ -557,7 +597,7 @@ func (m *Manager) reconcileHostTrustRunners(ctx context.Context, active map[stri
 			continue
 		}
 		reason := fmt.Sprintf("host trust generation changed from %s to %s", instance.HostTrustGeneration, current.Generation)
-		if err := m.retireInstance(context.Background(), instance, reason); err != nil {
+		if err := m.retireInstance(ctx, instance, reason); err != nil {
 			m.warnf("[%s] old-generation retirement warning: %v\n", name, err)
 			continue
 		}
@@ -608,6 +648,11 @@ func (m *Manager) startHostTrustLeaseKeeper(parent context.Context) (func(Provis
 					if instance.HostTrustGeneration != current.Generation {
 						if err := m.issueHostTrustLease(ctx, name, current); err != nil {
 							m.warnf("[%s] host trust initial stale-generation revocation warning: %v\n", name, err)
+							if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, err); fenceErr != nil {
+								m.warnf("[%s] host trust initial registration fencing warning: %v\n", name, fenceErr)
+							}
+							instance.Phase = LifecycleQuarantined
+							active[name] = instance
 						}
 						continue
 					}
@@ -617,6 +662,11 @@ func (m *Manager) startHostTrustLeaseKeeper(parent context.Context) (func(Provis
 					}
 					if err := m.issueHostTrustLease(ctx, name, current); err != nil {
 						m.warnf("[%s] host trust initial lease refresh warning: %v\n", name, err)
+						if fenceErr := m.fenceHostTrustRunnerRegistration(ctx, instance, err); fenceErr != nil {
+							m.warnf("[%s] host trust initial registration fencing warning: %v\n", name, fenceErr)
+						}
+						instance.Phase = LifecycleQuarantined
+						active[name] = instance
 					}
 				}
 			}

--- a/internal/pool/host_trust_test.go
+++ b/internal/pool/host_trust_test.go
@@ -393,11 +393,59 @@ func TestHostTrustReconciliationFencesLeaseWhenTransportRefreshFails(t *testing.
 	if activator.calls != 1 {
 		t.Fatalf("activation calls = %d, want 1", activator.calls)
 	}
-	if got := atomic.LoadInt32(&github.runnerByNameCalls); got != 0 {
-		t.Fatalf("GitHub status calls = %d, want no lease path after activation failure", got)
+	if got := atomic.LoadInt32(&github.runnerByNameCalls); got != 1 {
+		t.Fatalf("GitHub status calls = %d, want one exact registration fence lookup after activation failure", got)
 	}
-	if fake.commandCount("rm -f '/run/epar/host-trust-lease.json'") != 1 {
-		t.Fatalf("guest commands = %v, want exact lease fence", fake.commands)
+	if got := atomic.LoadInt32(&github.deleteCalls); got != 1 {
+		t.Fatalf("GitHub registration fence calls = %d, want 1", got)
+	}
+	if got := active["runner-1"].Phase; got != LifecycleQuarantined {
+		t.Fatalf("runner phase = %s, want %s", got, LifecycleQuarantined)
+	}
+	if fake.commandCount("rm -f '/run/epar/host-trust-lease.json'") != 0 {
+		t.Fatalf("guest commands = %v, want immediate exact GitHub fence without a second blocked transport attempt", fake.commands)
+	}
+}
+
+func TestHostTrustReconciliationFencesRegistrationWhenIdleLeaseRefreshFails(t *testing.T) {
+	fake := &fakeProvider{execErrs: []error{errors.New("lease transport unavailable"), nil}}
+	github := &fakeGitHub{runner: gh.Runner{Name: "runner-1", ID: 42, Status: "online"}, found: true}
+	manager := Manager{
+		Config: config.Config{
+			Image:    config.ImageConfig{HostTrustMode: config.HostTrustModeOverlay, HostTrustScopes: []string{"system"}},
+			Timeouts: config.TimeoutConfig{CommandSeconds: 5},
+		},
+		Provider: fake,
+		GitHub:   github,
+	}
+	current := hosttrust.Snapshot{Generation: "g1", HostOS: "linux", Scopes: []string{"system"}, Certificates: []hosttrust.Certificate{{Name: "root.crt", PEM: []byte("pem")}}, CollectedAt: time.Now().UTC()}
+	active := map[string]ProvisionedInstance{"runner-1": {Name: "runner-1", RunnerID: 42, HostTrustGeneration: "g1", ProviderOwned: true, Phase: LifecycleReady}}
+
+	manager.reconcileHostTrustRunners(context.Background(), active, current, make(map[string]bool))
+
+	if got := atomic.LoadInt32(&github.deleteCalls); got != 1 {
+		t.Fatalf("GitHub registration fence calls = %d, want 1", got)
+	}
+	github.mu.Lock()
+	deletedIDs := append([]int64(nil), github.deletedIDs...)
+	github.mu.Unlock()
+	if len(deletedIDs) != 1 || deletedIDs[0] != 42 {
+		t.Fatalf("deleted runner ids = %v, want [42]", deletedIDs)
+	}
+	if got := active["runner-1"].Phase; got != LifecycleQuarantined {
+		t.Fatalf("runner phase = %s, want %s", got, LifecycleQuarantined)
+	}
+}
+
+func TestHostTrustRegistrationFenceRejectsSameNameDifferentRunnerID(t *testing.T) {
+	github := &fakeGitHub{runner: gh.Runner{Name: "runner-1", ID: 43, Status: "online"}, found: true}
+	manager := Manager{GitHub: github}
+	err := manager.fenceHostTrustRunnerRegistration(context.Background(), ProvisionedInstance{Name: "runner-1", RunnerID: 42}, errors.New("lease unavailable"))
+	if err == nil || !strings.Contains(err.Error(), "does not match expected id=42") {
+		t.Fatalf("fence error = %v, want exact identity mismatch", err)
+	}
+	if got := atomic.LoadInt32(&github.deleteCalls); got != 0 {
+		t.Fatalf("GitHub delete calls = %d, want 0 for same-name identity mismatch", got)
 	}
 }
 

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -473,7 +473,9 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 							// receive a mismatching lease so no subsequent job can start.
 							currentHostTrust = current
 							if !dependencyCooldown {
-								trustRetired += m.reconcileHostTrustRunners(ctx, active, current, hostTrustBusyHandoff)
+								trustCtx, cancelTrust := m.steadyStateMaintenanceContext(ctx)
+								trustRetired += m.reconcileHostTrustRunners(trustCtx, active, current, hostTrustBusyHandoff)
+								cancelTrust()
 								hostTrustReconciled = true
 								nextHostTrustReconciliation = m.currentTime().Add(hostTrustRefreshInterval)
 							}
@@ -523,13 +525,17 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 					}
 				}
 				if currentHostTrust.Generation != "" && !dependencyCooldown && !hostTrustReconciled && (nextHostTrustReconciliation.IsZero() || !m.currentTime().Before(nextHostTrustReconciliation)) {
-					trustRetired += m.reconcileHostTrustRunners(ctx, active, currentHostTrust, hostTrustBusyHandoff)
+					trustCtx, cancelTrust := m.steadyStateMaintenanceContext(ctx)
+					trustRetired += m.reconcileHostTrustRunners(trustCtx, active, currentHostTrust, hostTrustBusyHandoff)
+					cancelTrust()
 					nextHostTrustReconciliation = m.currentTime().Add(hostTrustRefreshInterval)
 				}
 			}
 			if dependencyCooldown {
 				var localErr error
-				active, localErr = m.reconcileLocalInventory(active)
+				maintenanceCtx, cancelMaintenance := m.steadyStateMaintenanceContext(ctx)
+				active, localErr = m.reconcileLocalInventoryWithContext(maintenanceCtx, active)
+				cancelMaintenance()
 				if localErr != nil {
 					m.warnf("local pool housekeeping warning during replacement cooldown: %v\n", localErr)
 				}
@@ -537,10 +543,19 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 			}
 			if opts.ReplaceCompleted && !time.Now().Before(nextLivenessCheck) {
 				nextLivenessCheck = time.Now().Add(opts.MonitorInterval)
+				livenessCtx := ctx
+				cancelLiveness := func() {}
+				if m.hostTrustEnabled() {
+					// Health checks are advisory, while host-trust lease refresh is a
+					// safety deadline. Bound the complete sweep so one unreachable
+					// provider instance cannot starve every runner's lease cadence.
+					livenessCtx, cancelLiveness = context.WithTimeout(ctx, hostTrustRefreshInterval/2)
+				}
 				for name, vm := range active {
-					alive, reason, err := m.runnerAlive(ctx, vm)
+					alive, reason, err := m.runnerAlive(livenessCtx, vm)
 					if err != nil {
 						if ctx.Err() != nil {
+							cancelLiveness()
 							return cleanup()
 						}
 						recordRunnerLiveness(confirmedInactiveChecks, name, alive, reason, err)
@@ -557,16 +572,17 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 						continue
 					}
 					if reason == runnerProcessInactiveReason {
-						m.captureRunnerReadinessDiagnostics(name, vm.GuestLogPath)
+						m.captureRunnerReadinessDiagnostics(livenessCtx, name, vm.GuestLogPath)
 					}
 					m.infof("[%s] runner is finished or unhealthy: %s\n", name, reason)
-					if err := m.retireInstance(context.Background(), vm, reason); err != nil {
+					if err := m.retireInstance(livenessCtx, vm, reason); err != nil {
 						m.warnf("[%s] retirement warning: %v\n", name, err)
 						continue
 					}
 					delete(active, name)
 					delete(confirmedInactiveChecks, name)
 				}
+				cancelLiveness()
 			}
 			var reconcileErr error
 			beforeReconcile := active
@@ -574,11 +590,17 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 			if attemptErr != nil {
 				return errors.Join(attemptErr, m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
 			}
-			active, reconcileErr = m.reconcilePhysicalPool(attemptCtx, active, opts.Register)
+			maintenanceCtx, cancelMaintenance := m.steadyStateMaintenanceContext(attemptCtx)
+			active, reconcileErr = m.reconcilePhysicalPool(maintenanceCtx, active, opts.Register)
+			cancelMaintenance()
 			cancelAttempt()
 			if reconcileErr != nil {
 				if ctx.Err() != nil {
 					return cleanup()
+				}
+				if errors.Is(reconcileErr, context.DeadlineExceeded) {
+					m.warnf("pool reconciliation exceeded the host-trust maintenance budget; preserving exact capacity and retrying after lease refresh: %v\n", reconcileErr)
+					continue
 				}
 				if handled, outageErr := m.deferExternalOutage("steady-state-pool-reconciliation", reconcileErr); handled {
 					if outageErr != nil {
@@ -598,9 +620,15 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 			if attemptErr != nil {
 				return errors.Join(attemptErr, m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
 			}
-			active, reconcileErr = m.reduceOverCapacity(attemptCtx, active, opts.Instances, opts.Register)
+			maintenanceCtx, cancelMaintenance = m.steadyStateMaintenanceContext(attemptCtx)
+			active, reconcileErr = m.reduceOverCapacity(maintenanceCtx, active, opts.Instances, opts.Register)
+			cancelMaintenance()
 			cancelAttempt()
 			if reconcileErr != nil {
+				if errors.Is(reconcileErr, context.DeadlineExceeded) && ctx.Err() == nil {
+					m.warnf("over-capacity reconciliation exceeded the host-trust maintenance budget; preserving exact capacity and retrying after lease refresh: %v\n", reconcileErr)
+					continue
+				}
 				if handled, outageErr := m.deferExternalOutage("steady-state-over-capacity-reconciliation", reconcileErr); handled {
 					if outageErr != nil {
 						return m.cleanupAfterPoolFailure(outageErr, active, opts.KeepOnExit)
@@ -644,9 +672,15 @@ func (m *Manager) RunPool(ctx context.Context, opts RunOptions) error {
 				if attemptErr != nil {
 					return errors.Join(attemptErr, m.cleanupAfterTerminalFailure(active, opts.KeepOnExit))
 				}
-				active, err = m.reconcilePhysicalPool(attemptCtx, active, opts.Register)
+				maintenanceCtx, cancelMaintenance := m.steadyStateMaintenanceContext(attemptCtx)
+				active, err = m.reconcilePhysicalPool(maintenanceCtx, active, opts.Register)
+				cancelMaintenance()
 				cancelAttempt()
 				if err != nil {
+					if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+						m.warnf("[%s] replacement preallocation reconciliation exceeded the host-trust maintenance budget; retrying after lease refresh: %v\n", name, err)
+						break
+					}
 					if handled, outageErr := m.deferExternalOutage("replacement-preallocation-reconciliation", err); handled {
 						if outageErr != nil {
 							return m.cleanupAfterPoolFailure(outageErr, active, opts.KeepOnExit)
@@ -856,6 +890,22 @@ func (m *Manager) reconcilePhysicalPool(ctx context.Context, known map[string]Pr
 			continue
 		}
 		delete(remoteByName, name)
+		if m.LifecycleState != nil && vm.RunnerID == 0 {
+			cause := fmt.Errorf("same-name GitHub runner id=%d cannot be adopted because no immutable runner id was recorded", runner.ID)
+			vm.Phase = LifecycleQuarantined
+			reconciled[name] = vm
+			m.quarantineLifecycle(context.WithoutCancel(ctx), name, cause)
+			m.warnf("[%s] reconciliation quarantined exact provider capacity with an unidentified same-name GitHub runner: %v\n", name, cause)
+			continue
+		}
+		if vm.RunnerID != 0 && runner.ID != vm.RunnerID {
+			cause := fmt.Errorf("same-name GitHub runner id=%d does not match persisted immutable id=%d", runner.ID, vm.RunnerID)
+			vm.Phase = LifecycleQuarantined
+			reconciled[name] = vm
+			m.quarantineLifecycle(context.WithoutCancel(ctx), name, cause)
+			m.warnf("[%s] reconciliation quarantined exact provider capacity after GitHub identity changed: %v\n", name, cause)
+			continue
+		}
 		vm.RunnerID = runner.ID
 		if err := m.recordLifecycleJobObservation(ctx, runner); err != nil {
 			vm.Phase = LifecycleQuarantined
@@ -978,6 +1028,13 @@ func (m *Manager) reconcileLocalInventoryWithContext(ctx context.Context, known 
 			return known, fmt.Errorf("verify lifecycle ownership for %s: %w", local.Name, ownershipErr)
 		}
 		vm.ProviderOwned = owned
+		if owned && m.LifecycleState != nil {
+			record, recordErr := m.LifecycleState.Read(ctx, local.Name)
+			if recordErr != nil {
+				return known, fmt.Errorf("read lifecycle identity for %s: %w", local.Name, recordErr)
+			}
+			vm.RunnerID = record.GitHub.RunnerID
+		}
 		if !owned {
 			providerID := local.ProviderID
 			if providerID == "" {
@@ -1136,6 +1193,13 @@ func (m *Manager) currentTime() time.Time {
 		return m.now()
 	}
 	return time.Now()
+}
+
+func (m *Manager) steadyStateMaintenanceContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if !m.hostTrustEnabled() {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, hostTrustRefreshInterval/2)
 }
 
 func (m *Manager) randomValue() float64 {
@@ -1746,7 +1810,7 @@ func (m *Manager) provisionOneAttempt(ctx context.Context, name string, register
 			runner, err = m.waitRunnerReadyAndHealthy(ctx, vm, time.Duration(m.Config.Timeouts.GitHubOnlineSeconds)*time.Second, allowBusy)
 			return err
 		}); err != nil {
-			m.captureRunnerReadinessDiagnostics(name, guestLogPath)
+			m.captureRunnerReadinessDiagnostics(ctx, name, guestLogPath)
 			return vm, err
 		}
 		vm.RunnerID = runner.ID
@@ -1896,8 +1960,8 @@ func (m *Manager) waitRunnerReadyAndHealthy(ctx context.Context, vm ProvisionedI
 	}
 }
 
-func (m *Manager) captureRunnerReadinessDiagnostics(name, guestLogPath string) {
-	diagnosticCtx, cancel := context.WithTimeout(context.Background(), runnerReadinessDiagnosticsTimeout)
+func (m *Manager) captureRunnerReadinessDiagnostics(ctx context.Context, name, guestLogPath string) {
+	diagnosticCtx, cancel := context.WithTimeout(ctx, runnerReadinessDiagnosticsTimeout)
 	defer cancel()
 	_, err := m.execGuest(
 		diagnosticCtx,

--- a/internal/pool/manager_test.go
+++ b/internal/pool/manager_test.go
@@ -1639,6 +1639,53 @@ func TestQuarantinedRunnersAdoptOrRetireAfterGitHubRecovery(t *testing.T) {
 	}
 }
 
+func TestReconciliationDoesNotAdoptSameNameDifferentRunnerID(t *testing.T) {
+	p := &fakeProvider{instances: []provider.Instance{{Name: "epar-test-runner", State: "running"}}}
+	g := &fakeGitHub{listRunners: []gh.Runner{{Name: "epar-test-runner", ID: 43, Status: "online"}}}
+	manager := newRegisteredTestManager(t, p, g)
+	known := map[string]ProvisionedInstance{
+		"epar-test-runner": {Name: "epar-test-runner", RunnerID: 42, Phase: LifecycleQuarantined},
+	}
+
+	active, err := manager.reconcilePhysicalPool(context.Background(), known, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := active["epar-test-runner"].Phase; got != LifecycleQuarantined {
+		t.Fatalf("runner phase = %q, want quarantined", got)
+	}
+	if got := active["epar-test-runner"].RunnerID; got != 42 {
+		t.Fatalf("persisted runner id = %d, want 42", got)
+	}
+	if got := atomic.LoadInt32(&g.deleteCalls); got != 0 {
+		t.Fatalf("GitHub delete calls = %d, want 0 for same-name identity mismatch", got)
+	}
+}
+
+func TestControllerRestartHydratesImmutableRunnerIDBeforeReconciliation(t *testing.T) {
+	manager, store, name := readyLifecycleManager(t)
+	p := &fakeProvider{instances: []provider.Instance{{Name: name, ProviderID: "docker:ready-id", State: "running"}}}
+	g := &fakeGitHub{listRunners: []gh.Runner{{Name: name, ID: 43, Status: "online"}}}
+	manager.Provider = p
+	manager.Lifecycle = provider.AdaptLegacy(p)
+	manager.GitHub = g
+	manager.LifecycleState = store
+
+	active, err := manager.reconcilePhysicalPool(context.Background(), nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := active[name].Phase; got != LifecycleQuarantined {
+		t.Fatalf("runner phase = %q, want quarantined", got)
+	}
+	if got := active[name].RunnerID; got != 42 {
+		t.Fatalf("hydrated runner id = %d, want 42", got)
+	}
+	if got := atomic.LoadInt32(&g.deleteCalls); got != 0 {
+		t.Fatalf("GitHub delete calls = %d, want 0 for restart identity mismatch", got)
+	}
+}
+
 func TestReplacementBackoffSequenceJitterCapRetryAfterAndReset(t *testing.T) {
 	manager := Manager{Config: config.Config{Pool: config.PoolConfig{
 		ReplacementRetryInitialSeconds: 15,

--- a/internal/provider/dockersandboxes/provider_test.go
+++ b/internal/provider/dockersandboxes/provider_test.go
@@ -1585,12 +1585,12 @@ func TestPolicySchemaFailsClosed(t *testing.T) {
 }
 
 func TestPolicyReadbackAcceptsAttributedProviderBaselinePatterns(t *testing.T) {
-	fixture := policyFixture(`[{"id":"default-cert-validation","name":"default-cert-validation","policy_id":"local-policy","scope":"global","applies_to":"all","resource_type":"network","decision":"allow","resources":["**.openai.com:443","crl*.digicert.com:80","**"],"origin":"local","status":"active","editable":true}]`)
+	fixture := policyFixture(`[{"id":"default-cert-validation","name":"default-cert-validation","policy_id":"local-policy","scope":"global","applies_to":"all","resource_type":"network","decision":"allow","resources":["**.example.com:443","crl*.digicert.com:80","**"],"origin":"local","status":"active","editable":true}]`)
 	rules, err := parseNetworkPolicy([]byte(fixture), testName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rules) != 1 || !reflect.DeepEqual(rules[0].Resources, []string{"**.openai.com:443", "crl*.digicert.com:80", "**"}) {
+	if len(rules) != 1 || !reflect.DeepEqual(rules[0].Resources, []string{"**.example.com:443", "crl*.digicert.com:80", "**"}) {
 		t.Fatalf("provider baseline resources = %#v", rules)
 	}
 }


### PR DESCRIPTION
## Release intent

Merge the validated `develop` branch into `main` as the source commit for the planned v0.3.1 source-only release. This PR does not create the tag or GitHub Release.

## Included changes

- Prevent hung provider inventory and health operations from starving host-trust lease renewal.
- Quarantine affected local capacity and fence only the exact GitHub runner registration when trust maintenance fails.
- Preserve and validate immutable runner identity during restart reconciliation, rejecting unknown or mismatched registrations.
- Bound steady-state supervision work and apply fail-closed handling during initial lease maintenance.
- Document safe recovery from an already-held controller configuration lock and clarify lease-failure behavior.

## Validation

- PR #33 completed all 12 required checks successfully before its merge into `develop`.
- Focused pool tests and race tests passed, and independent verification found no P0-P2 blockers.
- A live Docker Sandboxes canary passed, and a two-runner pool remained responsive beyond a full lease lifetime with fresh leases on both guests.
- The release workflow will test the exact annotated v0.3.1 commit again before publishing.

## After merge

Create and push annotated tag `v0.3.1` at the resulting `main` commit, then manually dispatch the source-only Release workflow with the required confirmation. Tagging and release publication remain separate approval steps.