### PR TITLE
Promote automatic Docker Sandboxes prebuilt updates to main

### DIFF
--- a/.github/scripts/fetch-prebuilt-catalog.sh
+++ b/.github/scripts/fetch-prebuilt-catalog.sh
@@ -72,6 +72,6 @@ if [[ "$actual_digest" != "$layer_digest" ]]; then
   echo "catalog layer digest mismatch: expected $layer_digest, got $actual_digest" >&2
   exit 1
 fi
-jq -e '(.schemaVersion == 1) and (.artifactKind == "docker-sandboxes-template")' "$catalog_file" >/dev/null
+jq -e '((.schemaVersion == 1) or (.schemaVersion == 2)) and (.artifactKind == "docker-sandboxes-template")' "$catalog_file" >/dev/null
 
 mv -f -- "$catalog_file" "$output_file"

--- a/.github/workflows/docker-sandboxes-images.yml
+++ b/.github/workflows/docker-sandboxes-images.yml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: 'Profile to build. Full is candidate-only until its independent gates are enabled.'
+        description: 'Compatible v1 builds automatically advance this profile after its upstream and hosted gates pass.'
         required: true
         type: choice
         options:
@@ -36,7 +36,7 @@ on:
           - full
         default: act
       force_candidate:
-        description: 'Keep the result as a candidate even when the source-only tuple is eligible for alias advancement.'
+        description: 'Keep the result as a candidate even when compatible-v1 automatic promotion is eligible.'
         required: true
         type: boolean
         default: false
@@ -117,9 +117,80 @@ jobs:
           scripts/docker-sandboxes/validate-prebuilt.ps1 -Platform linux/amd64
           scripts/docker-sandboxes/validate-prebuilt.ps1 -Platform linux/arm64
 
+  upstream-gate:
+    name: Verify fresh upstream tag-producing workflow evidence
+    if: github.event_name != 'pull_request' && inputs.promote_candidate != true
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      profile: ${{ steps.gate.outputs.profile }}
+      eligible: ${{ steps.gate.outputs.eligible }}
+      evidence: ${{ steps.gate.outputs.evidence }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Evaluate upstream workflow, job, and step evidence
+        id: gate
+        shell: bash
+        env:
+          DISPATCH_PROFILE: ${{ inputs.profile }}
+          SCHEDULE_EXPRESSION: ${{ github.event.schedule }}
+          UPSTREAM_ACTIONS_READ_TOKEN: ${{ secrets.UPSTREAM_ACTIONS_READ_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          profile="${DISPATCH_PROFILE:-act}"
+          if [[ "$GITHUB_EVENT_NAME" == schedule ]]; then
+            case "$SCHEDULE_EXPRESSION" in
+              '37 23 */7 * *') profile=full ;;
+              '57 23 */7 * *') profile=act ;;
+              *) echo "unsupported schedule expression: $SCHEDULE_EXPRESSION" >&2; exit 1 ;;
+            esac
+          fi
+          case "$profile" in
+            act|full) ;;
+            *) echo "unsupported profile: $profile" >&2; exit 1 ;;
+          esac
+          result="$RUNNER_TEMP/upstream-gate.json"
+          if ! go run ./cmd/epar-prebuilt-publisher upstream-gate --profile "$profile" --output "$result"; then
+            jq -n --arg reason 'GitHub Actions metadata was unavailable or invalid; publication skipped without building or writing GHCR/catalog state' '{eligible:false,reason:$reason}' > "$result"
+          fi
+          eligible="$(jq -r 'if (.eligible | type) == "boolean" then (.eligible | tostring) else error("eligible must be boolean") end' "$result")"
+          reason="$(jq -er '.reason' "$result")"
+          evidence="$(jq -c '.evidence // {}' "$result")"
+          {
+            echo "profile=$profile"
+            echo "eligible=$eligible"
+            echo "evidence=$evidence"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo '## Docker Sandboxes upstream publication gate'
+            echo
+            echo "- Profile: \`$profile\`"
+            echo "- Eligible: \`$eligible\`"
+            echo "- Reason: $reason"
+            if [[ "$eligible" == true ]]; then
+              echo "- Upstream run: \`$(jq -r '.evidence.repository + "/actions/runs/" + (.evidence.runId | tostring)' "$result")\`"
+              echo "- Completed: \`$(jq -r '.evidence.completedAt' "$result")\`"
+            else
+              echo '- No source resolution, build, package push, catalog publication, or profile-tag movement was attempted.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   resolve:
     name: Resolve immutable upstream and publication state
-    if: github.event_name != 'pull_request' && inputs.promote_candidate != true
+    needs: upstream-gate
+    if: needs.upstream-gate.outputs.eligible == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -139,6 +210,7 @@ jobs:
       runner_arm64_digest: ${{ steps.runner.outputs.arm64_digest }}
       catalog_manifest_digest: ${{ steps.catalog.outputs.catalog_manifest_digest }}
       noop: ${{ steps.noop.outputs.noop }}
+      upstream_evidence: ${{ needs.upstream-gate.outputs.evidence }}
     steps:
       - name: Check out source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -257,16 +329,14 @@ jobs:
           tool_digest="sha256:$(jq -cS '{dockerfileFrontend,sbomGenerator,goBuilder,emulation,tini}' templates/docker-sandboxes/sources.lock.json | sha256sum | awk '{print $1}')"
           mapfile -t recipe_files < <(
             git ls-files --cached -- \
+              'templates/docker-sandboxes/.dockerignore' \
               'templates/docker-sandboxes/Dockerfile.prebuilt' \
               'templates/docker-sandboxes/helpers.sha256' \
-              'templates/docker-sandboxes/prebuilt.lock.json' \
               'templates/docker-sandboxes/prebuilt/**' \
               'templates/docker-sandboxes/guest/**' \
-              'templates/docker-sandboxes/hook-launcher/**' \
-              'templates/docker-sandboxes/egress-bridge/**' \
-              'templates/docker-sandboxes/profiles/**' \
-              'scripts/docker-sandboxes/**' \
-              'internal/prebuilt/**' | sort
+              'templates/docker-sandboxes/hook-launcher/main.go' \
+              'templates/docker-sandboxes/egress-bridge/main.go' \
+              'templates/docker-sandboxes/profiles/prebuilt.compatibility.json' | sort
           )
           ((${#recipe_files[@]} > 0))
           recipe_digest="sha256:$(printf '%s\n' "${recipe_files[@]}" | xargs sha256sum | sha256sum | awk '{print $1}')"
@@ -309,7 +379,7 @@ jobs:
             "packageRepository": "ghcr.io/solutionforest/ephemeral-action-runner/docker-sandboxes-template",
             "policies": {
               "act": {"enabled": true, "wizardDefault": false, "autoAdvance": true},
-              "full": {"enabled": false, "wizardDefault": false, "autoAdvance": false, "reason": "Full remains gated until independent two-platform EPAR acceptance passes"}
+              "full": {"enabled": true, "wizardDefault": true, "autoAdvance": true}
             },
             "entries": [],
             "aliases": {},
@@ -318,6 +388,8 @@ jobs:
           JSON
             echo 'catalog_manifest_digest=' >> "$GITHUB_OUTPUT"
           fi
+          jq '.policies.act = {enabled:true,wizardDefault:false,autoAdvance:true} | .policies.full = {enabled:true,wizardDefault:true,autoAdvance:true}' "$catalog_dir/catalog-state.json" > "$catalog_dir/catalog-state.tmp"
+          mv "$catalog_dir/catalog-state.tmp" "$catalog_dir/catalog-state.json"
           jq -e . "$catalog_dir/catalog-state.json" >/dev/null
 
       - name: Reconcile an interrupted catalog-first alias promotion
@@ -402,9 +474,8 @@ jobs:
           matching_entry="$RUNNER_TEMP/epar-catalog/matching-entry.json"
           noop=false
           if [[ "$FORCE_CANDIDATE" != true ]]; then
-            # Only a complete candidate or active entry can suppress a build.
-            # Superseded entries must not suppress a build because their package
-            # is no longer the catalog's current accepted result.
+            # Only an active entry can suppress a build. A matching candidate
+            # must be re-evaluated so a later fresh upstream gate can promote it.
             jq -c --arg profile "$PROFILE" --arg source "$SOURCE_INDEX_DIGEST" \
               --arg sourceAmd64 "$SOURCE_AMD64_DIGEST" --arg sourceArm64 "$SOURCE_ARM64_DIGEST" \
               --arg recipe "$RECIPE_DIGEST" --arg revision "$RECIPE_REVISION" --arg sourceLock "$SOURCE_LOCK_DIGEST" --arg tool "$TOOL_DIGEST" \
@@ -414,7 +485,7 @@ jobs:
                 $catalog.entries[] as $entry
                 | (([$catalog.transitions[]? | select(.packageIndexDigest == $entry.packageIndexDigest) | .toStatus] | last) // $entry.status) as $effectiveStatus
                 | select(
-                    ($effectiveStatus == "candidate" or $effectiveStatus == "active")
+                    $effectiveStatus == "active"
                     and $entry.profile == $profile
                     and $entry.source.indexDigest == $source
                     and $entry.source.platformDigests["linux/amd64"] == $sourceAmd64
@@ -1003,6 +1074,7 @@ jobs:
           IMPORT_READBACK: ${{ steps.gates.outputs.import_readback }}
           PROVENANCE_DIGEST: ${{ steps.gates.outputs.provenance_digest }}
           SBOM_DIGEST: ${{ steps.gates.outputs.sbom_digest }}
+          UPSTREAM_EVIDENCE: ${{ needs.resolve.outputs.upstream_evidence }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/epar-publisher"
@@ -1015,9 +1087,9 @@ jobs:
             --arg recipeDigest "$RECIPE_DIGEST" --arg recipeRevision "$RECIPE_REVISION" --arg sourceLockDigest "$SOURCE_LOCK_DIGEST" --arg toolDigest "$TOOL_DIGEST" --arg runtime "$RUNTIME_CONTRACT" \
             --arg runnerVersion "$RUNNER_VERSION" --arg runnerAmd64 "$RUNNER_AMD64_DIGEST" --arg runnerArm64 "$RUNNER_ARM64_DIGEST" \
             --arg provenanceDigest "$PROVENANCE_DIGEST" --arg sbomDigest "$SBOM_DIGEST" --arg attestationDigest "$PROVENANCE_DIGEST" \
-            --arg candidateId "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${PROFILE}-${PACKAGE_INDEX_DIGEST#sha256:}" --argjson platforms "$package_platforms" --argjson tools "$tools_json" \
+            --arg candidateId "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${PROFILE}-${PACKAGE_INDEX_DIGEST#sha256:}" --argjson platforms "$package_platforms" --argjson tools "$tools_json" --argjson upstream "$UPSTREAM_EVIDENCE" \
             --arg sourceRechecked "$SOURCE_RECHECKED" --arg provenanceGenerated "$PROVENANCE_GENERATED" --arg sbomGenerated "$SBOM_GENERATED" --arg attestationVerified "$ATTESTATION_VERIFIED" --arg runtimeValidated "$RUNTIME_VALIDATED" --arg importReadback "$IMPORT_READBACK" \
-            '{profile:$profile,channel:"stable",sourceReference:$sourceReference,sourceTag:$sourceTag,packageRepository:$packageRepository,packageReference:$packageReference,packageIndexDigest:$packageDigest,packagePlatforms:$platforms,recipe:{digest:$recipeDigest,runtimeContract:$runtime,templateSchema:2,recipeRevision:$recipeRevision,sourceLockDigest:$sourceLockDigest,toolDigest:$toolDigest},runner:{selector:"latest",version:$runnerVersion,assetDigests:{"linux/amd64":$runnerAmd64,"linux/arm64":$runnerArm64},overlayRequired:false},tools:$tools,evidence:{provenanceDigest:$provenanceDigest,sbomDigest:$sbomDigest,attestationDigest:$attestationDigest},gates:{sourceResolved:true,sourceRechecked:($sourceRechecked == "true"),buildSucceeded:true,platformsValidated:true,importReadback:($importReadback == "true"),runtimeValidated:($runtimeValidated == "true"),provenanceGenerated:($provenanceGenerated == "true"),sbomGenerated:($sbomGenerated == "true"),attestationVerified:($attestationVerified == "true")},candidateId:$candidateId}' > "$input"
+            '{profile:$profile,channel:"stable",sourceReference:$sourceReference,sourceTag:$sourceTag,packageRepository:$packageRepository,packageReference:$packageReference,packageIndexDigest:$packageDigest,packagePlatforms:$platforms,recipe:{digest:$recipeDigest,runtimeContract:$runtime,templateSchema:2,recipeRevision:$recipeRevision,sourceLockDigest:$sourceLockDigest,toolDigest:$toolDigest},runner:{selector:"latest",version:$runnerVersion,assetDigests:{"linux/amd64":$runnerAmd64,"linux/arm64":$runnerArm64},overlayRequired:false},tools:$tools,evidence:{provenanceDigest:$provenanceDigest,sbomDigest:$sbomDigest,attestationDigest:$attestationDigest},gates:{sourceResolved:true,sourceRechecked:($sourceRechecked == "true"),buildSucceeded:true,platformsValidated:true,importReadback:($importReadback == "true"),runtimeValidated:($runtimeValidated == "true"),provenanceGenerated:($provenanceGenerated == "true"),sbomGenerated:($sbomGenerated == "true"),attestationVerified:($attestationVerified == "true")},upstream:$upstream,candidateId:$candidateId}' > "$input"
           if [[ "$SOURCE_RECHECKED" != true ]]; then
             jq --arg immutable "${SOURCE_REPOSITORY}@${SOURCE_INDEX_DIGEST}" '.sourceReference = $immutable' "$input" > "$input.tmp"
             mv "$input.tmp" "$input"
@@ -1050,7 +1122,7 @@ jobs:
             echo "- Profile: \`${{ needs.resolve.outputs.profile }}\`"
             echo "- Package: \`${PACKAGE_REF}\`"
             echo "- Index digest: \`${INDEX_DIGEST}\`"
-            echo '- Candidate assembly, immutable package tagging, hosted two-platform smoke checks, and OCI evidence completed; real Sandbox acceptance is performed later through temporary EPAR pools.'
+            echo '- Candidate assembly, immutable package tagging, hosted two-platform smoke checks, and OCI evidence completed. Compatible v1 packages may be promoted automatically; real Sandbox acceptance remains factual only when separately performed.'
             echo '- This workflow has contents:read and does not commit, tag, release, open a pull request, or push Git refs.'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -1059,7 +1131,7 @@ jobs:
     needs:
       - resolve
       - publish
-    if: always() && needs.resolve.outputs.noop != 'true' && needs.publish.result == 'success'
+    if: always() && needs.resolve.result == 'success' && needs.resolve.outputs.noop != 'true' && needs.publish.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -1305,7 +1377,7 @@ jobs:
             alias_moved=true
             [[ "$(oras resolve "$alias_ref")" == "${PACKAGE_REF##*@}" ]]
             trap - EXIT
-            echo 'Signed catalog was moved before the authorized source-only profile alias; pointer rollback was armed until both readbacks passed.' >> "$GITHUB_STEP_SUMMARY"
+            echo 'Signed catalog was moved before the authorized compatible-v1 profile alias; pointer rollback was armed until both readbacks passed.' >> "$GITHUB_STEP_SUMMARY"
           elif [[ "$ALLOW_ALIAS" == true ]]; then
             trap - EXIT
             echo "Signed immutable candidate catalog: ${immutable_catalog_ref}" >> "$GITHUB_STEP_SUMMARY"

--- a/cmd/epar-prebuilt-publisher/main.go
+++ b/cmd/epar-prebuilt-publisher/main.go
@@ -10,9 +10,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/solutionforest/ephemeral-action-runner/internal/prebuilt"
@@ -20,10 +22,12 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fatal(errors.New("usage: epar-prebuilt-publisher <plan|accept|promote|catalog|reconcile-alias|verify-catalog|verify-package> [flags]"))
+		fatal(errors.New("usage: epar-prebuilt-publisher <upstream-gate|plan|accept|promote|catalog|reconcile-alias|verify-catalog|verify-package> [flags]"))
 	}
 	var err error
 	switch os.Args[1] {
+	case "upstream-gate":
+		err = upstreamGateCommand(os.Args[2:])
 	case "plan":
 		err = planCommand(os.Args[2:])
 	case "accept":
@@ -44,6 +48,37 @@ func main() {
 	if err != nil {
 		fatal(err)
 	}
+}
+
+func upstreamGateCommand(args []string) error {
+	flags := flag.NewFlagSet("upstream-gate", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	profile := flags.String("profile", "", "Act or Full profile to evaluate")
+	outputPath := flags.String("output", "", "upstream gate result JSON path")
+	baseURL := flags.String("base-url", "", "GitHub API base URL")
+	anonymous := flags.Bool("anonymous", false, "do not send a GitHub API token")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *profile == "" || *outputPath == "" {
+		return errors.New("upstream-gate requires --profile and --output")
+	}
+	token := ""
+	if !*anonymous {
+		token = strings.TrimSpace(os.Getenv("UPSTREAM_ACTIONS_READ_TOKEN"))
+		if token == "" {
+			token = strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+		}
+	}
+	result, err := (prebuilt.UpstreamGateClient{HTTPClient: &http.Client{Timeout: 30 * time.Second}, BaseURL: *baseURL, Token: token}).Evaluate(context.Background(), *profile)
+	if err != nil {
+		return fmt.Errorf("evaluate upstream workflow gate: %w", err)
+	}
+	if err := writeJSON(*outputPath, result); err != nil {
+		return fmt.Errorf("write upstream gate result: %w", err)
+	}
+	fmt.Printf("eligible=%t\nreason=%s\n", result.Eligible, result.Reason)
+	return nil
 }
 
 func acceptCommand(args []string) error {

--- a/cmd/epar-prebuilt-publisher/workflow_contract_test.go
+++ b/cmd/epar-prebuilt-publisher/workflow_contract_test.go
@@ -34,7 +34,7 @@ func TestWorkflowVerifiesMatchingPackageBeforeNoop(t *testing.T) {
 	for _, required := range []string{
 		`matching_entries="$RUNNER_TEMP/epar-catalog/matching-entries.json"`,
 		`matching_entry="$RUNNER_TEMP/epar-catalog/matching-entry.json"`,
-		`($effectiveStatus == "candidate" or $effectiveStatus == "active")`,
+		`$effectiveStatus == "active"`,
 		`$entry.gates.sourceRechecked == true`,
 		`$entry.gates.attestationVerified == true`,
 		`go run ./cmd/epar-prebuilt-publisher verify-package`,
@@ -53,6 +53,61 @@ func TestWorkflowVerifiesMatchingPackageBeforeNoop(t *testing.T) {
 	noOpAssignment := strings.Index(noopStep, "noop=true")
 	if verify < 0 || noOpAssignment < 0 || verify >= noOpAssignment {
 		t.Fatalf("immutable package verification must precede noop=true: verify=%d noop=%d", verify, noOpAssignment)
+	}
+}
+
+func TestWorkflowSkipsAllPublicationWorkWhenUpstreamGateIsNotGreen(t *testing.T) {
+	workflow := strings.ReplaceAll(readPublisherWorkflow(t), "\r\n", "\n")
+	gate := strings.Index(workflow, "  upstream-gate:\n")
+	resolve := strings.Index(workflow, "\n  resolve:\n")
+	build := strings.Index(workflow, "\n  build:\n")
+	if gate < 0 || resolve <= gate || build <= resolve {
+		t.Fatalf("upstream gate must precede resolve and build: gate=%d resolve=%d build=%d", gate, resolve, build)
+	}
+	gateJob := workflow[gate:resolve]
+	resolveJob := workflow[resolve:build]
+	for _, required := range []string{
+		`go run ./cmd/epar-prebuilt-publisher upstream-gate --profile "$profile" --output "$result"`,
+		`UPSTREAM_ACTIONS_READ_TOKEN: ${{ secrets.UPSTREAM_ACTIONS_READ_TOKEN || github.token }}`,
+		`if (.eligible | type) == "boolean" then (.eligible | tostring)`,
+		`publication skipped without building or writing GHCR/catalog state`,
+		`No source resolution, build, package push, catalog publication, or profile-tag movement was attempted.`,
+	} {
+		if !strings.Contains(gateJob, required) {
+			t.Fatalf("upstream gate is missing %q", required)
+		}
+	}
+	if !strings.Contains(resolveJob, "needs: upstream-gate") || !strings.Contains(resolveJob, "if: needs.upstream-gate.outputs.eligible == 'true'") {
+		t.Fatal("resolve is not fail-closed behind the upstream gate")
+	}
+	if !strings.Contains(workflow, "if: always() && needs.resolve.result == 'success' && needs.resolve.outputs.noop != 'true' && needs.publish.result == 'success'") {
+		t.Fatal("automatic promotion can bypass a skipped or failed gated resolve job")
+	}
+	if strings.Contains(gateJob, "docker/login-action") || strings.Contains(gateJob, "oras tag") || strings.Contains(gateJob, "docker/build-push-action") {
+		t.Fatal("upstream gate must not write package or catalog state")
+	}
+}
+
+func TestWorkflowRecipeDigestIncludesOnlyArtifactInputs(t *testing.T) {
+	workflow := strings.ReplaceAll(readPublisherWorkflow(t), "\r\n", "\n")
+	start := strings.Index(workflow, "      - name: Compute immutable recipe and tool identities\n")
+	if start < 0 {
+		t.Fatal("cannot find recipe digest step")
+	}
+	end := strings.Index(workflow[start:], "      - name: Fetch current signed catalog state")
+	if end < 0 {
+		t.Fatalf("cannot isolate recipe digest step: start=%d end=%d", start, end)
+	}
+	recipe := workflow[start : start+end]
+	for _, required := range []string{"Dockerfile.prebuilt", "helpers.sha256", "prebuilt/**", "guest/**", "hook-launcher/main.go", "egress-bridge/main.go", "prebuilt.compatibility.json"} {
+		if !strings.Contains(recipe, required) {
+			t.Fatalf("artifact recipe is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"prebuilt.lock.json", "internal/prebuilt", "scripts/docker-sandboxes", "profiles/*.compatibility.json", "_test.go"} {
+		if strings.Contains(recipe, forbidden) {
+			t.Fatalf("artifact recipe includes host/policy input %q", forbidden)
+		}
 	}
 }
 
@@ -247,7 +302,7 @@ func TestCatalogFetcherRejectsLayerPathsAndValidatesExactBlob(t *testing.T) {
 		`select((.layers | length) == 1)`,
 		`oras blob fetch --output "$catalog_file" "${repository}@${layer_digest}"`,
 		`actual_digest="sha256:$(sha256sum "$catalog_file"`,
-		`(.schemaVersion == 1) and (.artifactKind == "docker-sandboxes-template")`,
+		`((.schemaVersion == 1) or (.schemaVersion == 2)) and (.artifactKind == "docker-sandboxes-template")`,
 	} {
 		if !strings.Contains(script, required) {
 			t.Fatalf("catalog fetcher is missing %q", required)
@@ -319,6 +374,7 @@ func TestWorkflowBuildsAndPromotesFullWithoutPersistentNativeRunners(t *testing.
 		`epar-prebuilt-${PROFILE}-${digest_prefix}-arm64`,
 		`alias_tag="${PROFILE}-latest"`,
 		`oras tag "${PACKAGE_REPOSITORY}@${CANDIDATE_DIGEST}" "$alias_tag"`,
+		`.policies.full = {enabled:true,wizardDefault:true,autoAdvance:true}`,
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("Full publication/acceptance contract is missing %q", required)

--- a/docs/development/docker-sandboxes-prebuilt.md
+++ b/docs/development/docker-sandboxes-prebuilt.md
@@ -4,13 +4,13 @@ EPAR publishes its Docker Sandboxes template as an immutable multi-platform OCI 
 
 The canonical source is `ghcr.io/catthehacker/ubuntu`. The public package is `ghcr.io/solutionforest/ephemeral-action-runner/docker-sandboxes-template`. Docker Hub is never used as a source fallback because its OCI identities may differ from GHCR even when the logical image content matches.
 
-Act (`act-latest`) and Full (`full-latest`) use the same publication, verification, and runtime contracts. The signed catalog records candidates before acceptance; runtime resolution follows only an active profile alias.
+Act (`act-latest`) and Full (`full-latest`) use the same publication, verification, and runtime contracts. A package declaring `docker-sandboxes-v1` and template schema 2 is compatible regardless of its exact recipe, source lock, runner, or tool identities; those identities remain signed provenance and must agree exactly across labels, catalog, provenance, SBOM, attestations, and receipts. The signed catalog records every package and runtime resolution follows only an active profile alias.
 
 ## Workflow triggers and hosted build gates
 
-`.github/workflows/docker-sandboxes-images.yml` checks the Catthehacker day-of-month cadence at 23:37 UTC for Full and 23:57 UTC for Act, approximately 6–12 hours after the upstream 12:00 UTC schedule, supports manual dispatch, and publishes for recipe-related pushes only on `main`. The `*/7` day-of-month expression mirrors the upstream calendar pattern rather than one fixed weekday. GitHub executes both cron expressions only from the default branch and may delay scheduled starts under load. Pull requests to `develop` or `main` that change a publisher, recipe, or committed-asset path run publisher, signed-evidence, and asset validation without logging in to GHCR, building a package, or pushing any manifest. This prevents a normal `develop` to `main` promotion from publishing the same source change twice.
+`.github/workflows/docker-sandboxes-images.yml` checks the Catthehacker day-of-month cadence at 23:37 UTC for Full and 23:57 UTC for Act, approximately 6–12 hours after the upstream 12:00 UTC schedule, supports manual dispatch, and publishes for recipe-related pushes only on `main`. Before source resolution or any GHCR write, it inspects the newest tag-moving upstream run on `master`. Full requires a fresh successful scheduled `copy-full-image.yml` run and the exact successful four-job GHCR copy matrix that contains `full-latest`. Act requires a fresh scheduled `build-ubuntu.yml` run with one successful `Build base 24.04` job, a successful `Build and push ubuntu:act-24.04` step, and the expected Act test path; the signed evidence records whether that upstream test path succeeded or was skipped, because the current upstream workflow condition skips it. Unrelated flavor failures do not block Act, and EPAR's unchanged two-platform package smoke checks remain the automatic image-health gate. A newer manual run, pending/failed/stale/malformed state, missing job or step, API error, or evidence older than ten days exits successfully as publication skipped and records the reason only in the GitHub Actions summary. The `*/7` day-of-month expression mirrors the upstream calendar pattern rather than one fixed weekday. GitHub executes both cron expressions only from the default branch and may delay scheduled starts under load. Pull requests to `develop` or `main` that change a publisher, recipe, or committed-asset path run publisher, signed-evidence, and asset validation without logging in to GHCR, building a package, or pushing any manifest.
 
-Before allocating hosted build runners, the resolve job reads the signed moving catalog and compares the complete source, recipe, runtime, schema, runner, and locked-tool tuple. A candidate or active entry must also have all hosted build and signed-evidence gates set, and an active entry must still be the selected profile alias. When exactly one entry matches, the job runs `verify-package` against that entry's immutable package reference; this checks registry metadata, signed referrers, and claims without pulling image layers. Only a successful verification produces a no-op. No match starts a hosted build, an ambiguous match fails closed, and a package or evidence verification failure never silently falls back to rebuilding.
+Before allocating hosted build runners, the resolve job reads the signed moving catalog and compares the complete source, recipe, runtime, schema, runner, and locked-tool tuple. Only a verified active entry at the selected profile alias may suppress a build. A matching candidate is deliberately re-evaluated so a later run with fresh upstream evidence can promote it. Package verification checks registry metadata, signed referrers, and claims without pulling image layers; an ambiguous match fails closed and a package or evidence verification failure never silently falls back to rebuilding.
 
 The amd64 build runs on GitHub-hosted `ubuntu-latest`; the arm64 build runs on GitHub-hosted `ubuntu-24.04-arm`. The workflow has no persistent self-hosted runner dependency and no `EPAR_PREBUILT_LIVE` switch. Full jobs first reclaim disposable hosted-runner tool caches, require at least 40 GiB free before allocating 8 GiB of swap, serialize BuildKit execution, and allow a three-hour timeout; failing that capacity gate leaves Full unpublished rather than silently changing its recipe or dropping a platform. Hosted jobs resolve the GHCR source descriptor, build from its immutable digest, inspect both runnable platform manifests by digest, assemble an index from those exact digests, require exactly two descriptors, run package smoke checks, generate and sign one index-level SLSA provenance statement and one index-level SPDX SBOM, verify their referrers, and publish an immutable signed candidate catalog. Platform builds disable BuildKit's additional per-platform SBOM/provenance indexes because EPAR's trust decision uses the separately signed index-level evidence and catalog. The index-level SPDX document records the package, recipe, and exact platform identities rather than reproducing BuildKit's more detailed component inventory; this deliberate narrower audit scope avoids four additional per-publication GHCR version rows without weakening the evidence enforced by EPAR.
 
@@ -18,14 +18,14 @@ The workflow grants `contents: read`, `packages: write`, `attestations: write`, 
 
 ## Candidate publication contract
 
-Every new package is first recorded as `candidate`. Before manual acceptance, publication may create:
+Every new package is first assembled with an immutable candidate identity. After the hosted and upstream gates complete, a compatible v1/schema-2 package may be recorded and activated automatically; `force_candidate` retains it as a candidate and never moves an alias. Publication may create:
 
 - an immutable package index and canonical tag such as `<profile>-latest-pkg-<64 hex index digest>`;
 - exact amd64 and arm64 platform manifests;
 - signed SLSA provenance and SPDX SBOM referrers;
 - an immutable catalog object and canonical tag such as `catalog-v1-pkg-<64 hex catalog digest>`.
 
-On trusted `main`, candidate publication moves the signed `catalog-v1` ledger pointer but does not move the profile's `*-latest` alias. This makes a complete candidate discoverable to later metadata checks without activating it. Non-main candidate publication remains immutable-only, and first-catalog bootstrap still uses the exact signed immutable catalog.
+On trusted `main`, publication writes and verifies the immutable catalog, then moves `catalog-v1`, and moves the matching profile alias last only for an authorized compatible-v1 plan. Catalog and alias compare-and-swap, source recheck, readback, rollback, and interrupted-promotion reconciliation remain mandatory. A runtime-major mismatch, `force_candidate`, non-main run, source race, or incomplete gate may publish only immutable candidate state and cannot move the profile alias.
 
 Catalog readers resolve an exact catalog manifest, validate its artifact/config/single-layer media contract, and fetch that layer by descriptor digest into a caller-chosen file. They never extract the publisher-supplied OCI layer title as a filesystem path. New catalogs are published from controlled relative filenames, while this descriptor path remains compatible with the initial catalogs that recorded absolute runner-temporary titles.
 
@@ -35,7 +35,9 @@ GitHub Packages displays every OCI manifest as a package version, so one logical
 
 Production builds always use the resolved immutable upstream digest. The upstream tag is re-resolved before publication. If it moves during the build, the package remains an immutable candidate and no moving alias advances.
 
-The stable tuple is `(source index and platform digests, recipe digest and revision, runtime contract, template schema, runner version and asset digests, locked tool digests)`. Recipe, runtime, runner, tooling, schema, or platform changes always require fresh manual acceptance. After one profile tuple has completed two-platform acceptance, a later source-only Catthehacker digest change may auto-promote that profile only when the EPAR-controlled tuple is identical and every hosted package/evidence gate passes. Full never auto-promotes while disabled; its first protected acceptance enables later source-only auto-advancement.
+The runtime compatibility contract is `(runtime contract, template schema)`. Under `docker-sandboxes-v1` and schema 2, source, recipe, helper, runner, source-lock, and locked-tool changes are compatible by default and may auto-promote after fresh upstream evidence and all hosted package/evidence gates pass. Their exact values remain immutable signed provenance and unexplained package nondeterminism for an unchanged complete build tuple still fails closed. A breaking controller/template contract must declare a new runtime major such as `docker-sandboxes-v2`; it remains candidate-only until real Docker Sandboxes acceptance and protected manual promotion.
+
+The recipe digest includes only inputs that can affect the published artifact: `Dockerfile.prebuilt`, relevant `.dockerignore` behavior, guest and prebuilt runtime files, production Go sources compiled into the image, `helpers.sha256`, and the prebuilt compatibility profile. Tests, host-only validators, local-build profiles, publisher/catalog implementation, and policy files are excluded.
 
 `templates/docker-sandboxes/prebuilt.lock.json` commits only stable recipe and profile identities. Mutable profile enablement, wizard-default, automatic-advancement, acceptance, and revocation state belongs exclusively to the signed catalog, so protected Full promotion does not make a committed lock file stale.
 
@@ -103,11 +105,11 @@ For every run, the human reviewer verifies the private repository, exact workflo
 
 After both workflows pass on both platforms, stop both EPAR controllers. Verify that their GitHub runner records, exact Sandboxes, candidate staging directories, and unreferenced obsolete template generations are cleaned up. Hash each reviewed `active.json` receipt with SHA-256 and retain the two hashes with the four GitHub run IDs/URLs.
 
-No cross-repository PAT or GitHub App secret is added. The protected promotion reviewer uses authenticated GitHub access to inspect the four private-repository runs before approving the environment and entering their evidence into the workflow dispatch.
+No cross-repository PAT or GitHub App secret is required for protected private-repository acceptance review. The automatic upstream gate first uses the workflow's built-in token after feature-branch API validation; if that token cannot reliably read public upstream Actions metadata and anonymous access is also unreliable, the repository must provide `UPSTREAM_ACTIONS_READ_TOKEN` with read-only public Actions access. Missing or invalid access fails closed as publication skipped.
 
-## Protected promotion
+## Protected promotion and break-glass recovery
 
-Stable promotion must run from `main`, and the package evidence must have been produced from `refs/heads/main`. Feature-branch acceptance may be reused only when the main publication has the identical package index digest and complete tuple.
+Protected promotion is retained for runtime-major transitions and break-glass recovery. It must run from `main`, and the package evidence must have been produced from `refs/heads/main`. Feature-branch acceptance may be reused only when the main publication has the identical package index digest and complete tuple.
 
 Dispatch `docker-sandboxes-images.yml` on `main` with:
 
@@ -133,6 +135,7 @@ Catalog pointer and package-alias updates remain journaled by workflow rollback/
 
 ```text
 go run ./cmd/epar-prebuilt-publisher plan --catalog catalog-state.json --input publication-input.json --output plan.json
+go run ./cmd/epar-prebuilt-publisher upstream-gate --profile act --output upstream-gate.json
 go run ./cmd/epar-prebuilt-publisher accept --catalog catalog-state.json --input acceptance.json
 go run ./cmd/epar-prebuilt-publisher promote --protected --catalog catalog-state.json --plan candidate-plan.json
 go run ./cmd/epar-prebuilt-publisher catalog --catalog catalog-state.json --output catalog.canonical.json
@@ -140,7 +143,7 @@ go run ./cmd/epar-prebuilt-publisher verify-catalog --repository ghcr.io/solutio
 go run ./cmd/epar-prebuilt-publisher verify-package --reference ghcr.io/solutionforest/ephemeral-action-runner/docker-sandboxes-template@sha256:<64 hex> --entry publication-entry.json --repository ghcr.io/solutionforest/ephemeral-action-runner/docker-sandboxes-template --ref refs/heads/main --allowed-events schedule,workflow_dispatch,push
 ```
 
-`accept` appends immutable human-reviewed platform evidence. It accepts only `playwright-docker.yml` and `dockerhub-private-pull.yml` in `solutionforest/ephemeral-action-runner-test`, requires successful run evidence and exact receipt/runner identity, and does not itself move an alias. `promote --protected` requires complete hosted gates plus both reviewed platform records.
+`upstream-gate` reads public upstream workflow/run/job/step metadata and emits an eligibility result plus exact evidence; an ineligible result is not an error, while unavailable or malformed API data fails closed. `accept` appends immutable human-reviewed platform evidence. It accepts only `playwright-docker.yml` and `dockerhub-private-pull.yml` in `solutionforest/ephemeral-action-runner-test`, requires successful run evidence and exact receipt/runner identity, and does not itself move an alias. `promote --protected` requires complete hosted gates plus both reviewed platform records.
 
 ## Retention and revocation
 

--- a/internal/image/docker_sandboxes_prebuilt.go
+++ b/internal/image/docker_sandboxes_prebuilt.go
@@ -2,9 +2,7 @@ package image
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -470,104 +467,7 @@ func (m *Coordinator) validateDockerSandboxesPrebuiltRecipe(entry prebuilt.Entry
 	if entry.Recipe.RuntimeContract != "docker-sandboxes-v1" || entry.Recipe.TemplateSchema != 2 {
 		return fmt.Errorf("prebuilt package requires unsupported runtime contract %q or template schema %d", entry.Recipe.RuntimeContract, entry.Recipe.TemplateSchema)
 	}
-	sourceLockPath := filepath.Join(m.ProjectRoot, "templates", "docker-sandboxes", "sources.lock.json")
-	sourceLock, err := os.ReadFile(sourceLockPath)
-	if err != nil {
-		return fmt.Errorf("read supported prebuilt source lock: %w", err)
-	}
-	sourceDigest := sha256.Sum256(sourceLock)
-	wantSourceDigest := "sha256:" + hex.EncodeToString(sourceDigest[:])
-	wantToolDigest, err := dockerSandboxesSupportedPrebuiltToolDigest(sourceLock)
-	if err != nil {
-		return err
-	}
-	wantRecipeDigest, err := dockerSandboxesSupportedPrebuiltRecipeDigest(m.ProjectRoot)
-	if err != nil {
-		return err
-	}
-	if entry.Recipe.SourceLockDigest != wantSourceDigest {
-		return fmt.Errorf("prebuilt package source lock identity %s is not supported by this controller (expected %s)", entry.Recipe.SourceLockDigest, wantSourceDigest)
-	}
-	if entry.Recipe.ToolDigest != wantToolDigest {
-		return fmt.Errorf("prebuilt package tool identity %s is not supported by this controller (expected %s)", entry.Recipe.ToolDigest, wantToolDigest)
-	}
-	if entry.Recipe.Digest != wantRecipeDigest {
-		return fmt.Errorf("prebuilt package recipe identity %s is not supported by this controller (expected %s)", entry.Recipe.Digest, wantRecipeDigest)
-	}
 	return nil
-}
-
-func dockerSandboxesSupportedPrebuiltToolDigest(sourceLock []byte) (string, error) {
-	var lock map[string]json.RawMessage
-	if err := json.Unmarshal(sourceLock, &lock); err != nil {
-		return "", fmt.Errorf("parse supported prebuilt source lock: %w", err)
-	}
-	toolMaterial := make(map[string]any)
-	for _, key := range []string{"dockerfileFrontend", "sbomGenerator", "goBuilder", "emulation", "tini"} {
-		value, ok := lock[key]
-		if !ok {
-			return "", fmt.Errorf("supported prebuilt source lock omitted %s", key)
-		}
-		var canonical any
-		if err := json.Unmarshal(value, &canonical); err != nil {
-			return "", fmt.Errorf("canonicalize supported prebuilt tool identity %s: %w", key, err)
-		}
-		toolMaterial[key] = canonical
-	}
-	toolJSON, err := json.Marshal(toolMaterial)
-	if err != nil {
-		return "", err
-	}
-	// The publisher defines this identity with `jq -cS | sha256sum`; jq emits
-	// one trailing newline. Preserve that byte so every controller platform
-	// verifies the same already-attested tool identity.
-	toolJSON = append(toolJSON, '\n')
-	toolDigest := sha256.Sum256(toolJSON)
-	return "sha256:" + hex.EncodeToString(toolDigest[:]), nil
-}
-
-func dockerSandboxesSupportedPrebuiltRecipeDigest(projectRoot string) (string, error) {
-	var paths []string
-	for _, root := range []string{filepath.Join(projectRoot, "templates", "docker-sandboxes"), filepath.Join(projectRoot, "scripts", "docker-sandboxes"), filepath.Join(projectRoot, "internal", "prebuilt")} {
-		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if entry.IsDir() {
-				return nil
-			}
-			relative, err := filepath.Rel(projectRoot, path)
-			if err != nil {
-				return err
-			}
-			relative = filepath.ToSlash(relative)
-			if strings.HasPrefix(relative, "templates/docker-sandboxes/") {
-				included := relative == "templates/docker-sandboxes/Dockerfile.prebuilt" || relative == "templates/docker-sandboxes/helpers.sha256" || relative == "templates/docker-sandboxes/prebuilt.lock.json"
-				for _, prefix := range []string{"templates/docker-sandboxes/prebuilt/", "templates/docker-sandboxes/guest/", "templates/docker-sandboxes/hook-launcher/", "templates/docker-sandboxes/egress-bridge/", "templates/docker-sandboxes/profiles/"} {
-					included = included || strings.HasPrefix(relative, prefix)
-				}
-				if !included {
-					return nil
-				}
-			}
-			paths = append(paths, relative)
-			return nil
-		})
-		if err != nil {
-			return "", fmt.Errorf("enumerate supported prebuilt recipe: %w", err)
-		}
-	}
-	sort.Strings(paths)
-	outer := sha256.New()
-	for _, relative := range paths {
-		content, err := os.ReadFile(filepath.Join(projectRoot, filepath.FromSlash(relative)))
-		if err != nil {
-			return "", err
-		}
-		digest := sha256.Sum256(content)
-		fmt.Fprintf(outer, "%s  %s\n", hex.EncodeToString(digest[:]), relative)
-	}
-	return "sha256:" + hex.EncodeToString(outer.Sum(nil)), nil
 }
 
 func (m *Coordinator) dockerSandboxesPrebuiltLocalManifest() (Manifest, error) {
@@ -731,6 +631,20 @@ func (m *Coordinator) activateCurrentDockerSandboxesPrebuilt(ctx context.Context
 	}
 	if receipt.Distribution != dockerSandboxesDistributionPrebuilt || receipt.ManifestHash != wantHash || receipt.Prebuilt == nil {
 		return false, nil
+	}
+	if err := m.validateDockerSandboxesPrebuiltRecipe(receipt.Prebuilt.Entry); err != nil {
+		return false, fmt.Errorf("validate cached prebuilt compatibility: %w", err)
+	}
+	switch receipt.Prebuilt.EffectiveStatus {
+	case prebuilt.StatusActive, prebuilt.StatusSuperseded:
+	case prebuilt.StatusCandidate:
+		if !receipt.Prebuilt.Acceptance {
+			return false, errors.New("cached candidate prebuilt package is not in explicit acceptance mode")
+		}
+	case prebuilt.StatusRevoked, prebuilt.StatusCriticalRevoked:
+		return false, &DockerSandboxesPrebuiltStatusError{Digest: receipt.Prebuilt.PackageIndexDigest, Status: receipt.Prebuilt.EffectiveStatus, Reason: receipt.Prebuilt.Entry.RevocationReason}
+	default:
+		return false, fmt.Errorf("cached prebuilt package has unsupported signed status %q", receipt.Prebuilt.EffectiveStatus)
 	}
 	if err := runtimeProvider.VerifyImportedTemplate(ctx, receipt.Artifact); err != nil {
 		if errors.Is(err, provider.ErrTemplateNotFound) {

--- a/internal/image/docker_sandboxes_prebuilt_test.go
+++ b/internal/image/docker_sandboxes_prebuilt_test.go
@@ -569,49 +569,31 @@ func TestDockerSandboxesCriticalRevocationAdmissionBlockPersistsButOrdinaryRevoc
 	}
 }
 
-func TestDockerSandboxesPrebuiltCompatibilityGateRejectsUnsupportedContractSchemaAndRecipe(t *testing.T) {
-	missingSourceTree := &Coordinator{ProjectRoot: t.TempDir()}
+func TestDockerSandboxesPrebuiltCompatibilityGateUsesRuntimeContractAndTemplateSchema(t *testing.T) {
+	coordinator := &Coordinator{ProjectRoot: t.TempDir()}
 	for name, recipe := range map[string]prebuilt.RecipeDescriptor{
 		"runtime-contract": {RuntimeContract: "docker-sandboxes-v2", TemplateSchema: 2},
 		"template-schema":  {RuntimeContract: "docker-sandboxes-v1", TemplateSchema: 3},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := missingSourceTree.validateDockerSandboxesPrebuiltRecipe(prebuilt.Entry{Recipe: recipe}); err == nil || !strings.Contains(err.Error(), "unsupported runtime contract") {
+			if err := coordinator.validateDockerSandboxesPrebuiltRecipe(prebuilt.Entry{Recipe: recipe}); err == nil || !strings.Contains(err.Error(), "unsupported runtime contract") {
 				t.Fatalf("unsupported compatibility was not rejected before source/package materialization: %v", err)
 			}
 		})
 	}
-	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatal(err)
-	}
-	unknownRecipe := dockerSandboxesPrebuiltFixture().Entry
-	unknownRecipe.Recipe.RuntimeContract = "docker-sandboxes-v1"
-	unknownRecipe.Recipe.TemplateSchema = 2
-	unknownRecipe.Recipe.Digest = "sha256:" + strings.Repeat("9", 64)
-	unknownRecipe.Recipe.SourceLockDigest = "sha256:" + strings.Repeat("a", 64)
-	unknownRecipe.Recipe.ToolDigest = "sha256:" + strings.Repeat("b", 64)
-	if err := (&Coordinator{ProjectRoot: repositoryRoot}).validateDockerSandboxesPrebuiltRecipe(unknownRecipe); err == nil || !strings.Contains(err.Error(), "not supported by this controller") {
-		t.Fatalf("unknown prebuilt recipe was not rejected: %v", err)
-	}
-}
-
-func TestDockerSandboxesSupportedPrebuiltToolDigestMatchesPublisherCanonicalJSON(t *testing.T) {
-	lock := []byte(`{
-		"dockerfileFrontend":{"reference":"frontend"},
-		"sbomGenerator":{"reference":"sbom"},
-		"goBuilder":{"version":"1.25"},
-		"emulation":{"backend":"qemu"},
-		"tini":{"version":"0.19.0"},
-		"ignored":{"changes":"do not affect the tool identity"}
-	}`)
-	got, err := dockerSandboxesSupportedPrebuiltToolDigest(lock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	const want = "sha256:6ddef591a74f68147acca7a9534bc19a3f1c21c2c70ce4d4dafa0692d379754c"
-	if got != want {
-		t.Fatalf("tool digest = %s, want publisher-compatible %s", got, want)
+	for _, digest := range []string{
+		"sha256:e1758810f0821c68d8dd1d8f34cd08394669683888675df7a870f3a191f969bc",
+		"sha256:7d13940d24b0e8e623aa3803e3ebedd63d9b05cbb5f954b6a9db6bdbd15ce800",
+	} {
+		entry := dockerSandboxesPrebuiltFixture().Entry
+		entry.Recipe.RuntimeContract = "docker-sandboxes-v1"
+		entry.Recipe.TemplateSchema = 2
+		entry.Recipe.Digest = digest
+		entry.Recipe.SourceLockDigest = "sha256:" + strings.Repeat("a", 64)
+		entry.Recipe.ToolDigest = "sha256:" + strings.Repeat("b", 64)
+		if err := coordinator.validateDockerSandboxesPrebuiltRecipe(entry); err != nil {
+			t.Fatalf("compatible recipe %s was rejected: %v", digest, err)
+		}
 	}
 }
 

--- a/internal/prebuilt/catalog.go
+++ b/internal/prebuilt/catalog.go
@@ -18,10 +18,14 @@ import (
 )
 
 const (
-	// CatalogSchemaVersion is bumped when catalog semantics, rather than a
-	// package entry, change.  Entries are append-only and can be retained by
-	// registry clients that understand an older schema.
-	CatalogSchemaVersion = 1
+	// LegacyCatalogSchemaVersion remains readable so existing signed catalogs
+	// and source-only promotions retain their canonical identity.
+	LegacyCatalogSchemaVersion = 1
+	// CatalogSchemaVersion adds compatible-v1 hosted promotion records. Older
+	// readers must fail closed instead of silently dropping that authority.
+	CatalogSchemaVersion = 2
+	// EntrySchemaVersion is independent of catalog-ledger semantics.
+	EntrySchemaVersion = 1
 
 	// CatalogArtifactKind identifies the OCI artifact represented by an entry.
 	CatalogArtifactKind = "docker-sandboxes-template"
@@ -59,8 +63,21 @@ const (
 )
 
 var (
-	digestPattern  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-	profilePattern = regexp.MustCompile(`^[a-z][a-z0-9.-]{0,31}$`)
+	digestPattern   = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	profilePattern  = regexp.MustCompile(`^[a-z][a-z0-9.-]{0,31}$`)
+	revisionPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
+const (
+	compatibleRuntimeContract = "docker-sandboxes-v1"
+	upstreamRepository        = "catthehacker/docker_images"
+	upstreamFullWorkflow      = ".github/workflows/copy-full-image.yml"
+	upstreamActWorkflow       = ".github/workflows/build-ubuntu.yml"
+	upstreamActGateJob        = "Build base 24.04"
+	upstreamFull24Job         = "copy image ghcr.io/christopherhx/runner-images:ubuntu24-runner-large-latest"
+	upstreamFull22Job         = "copy image ghcr.io/christopherhx/runner-images:ubuntu22-runner-large-latest"
+	upstreamFull20Job         = "copy image ghcr.io/christopherhx/runner-images:ubuntu20-runner-large-latest"
+	upstreamEvidenceMaxAge    = 10 * 24 * time.Hour
 )
 
 // ProfileEnabled reports whether a profile is supported by the publication
@@ -184,8 +201,8 @@ type ToolDescriptor struct {
 }
 
 // RecipeDescriptor binds package output to the committed EPAR recipe and
-// runtime contract. A controller can reject a package from a newer recipe
-// even if the source image itself is compatible.
+// runtime contract. Exact recipe and tool identities are provenance; runtime
+// compatibility is defined by RuntimeContract and TemplateSchema.
 type RecipeDescriptor struct {
 	Digest           string `json:"digest"`
 	RuntimeContract  string `json:"runtimeContract"`
@@ -239,8 +256,8 @@ func (g GateResults) HostedPass() bool {
 	return g.SourceResolved && g.SourceRechecked && g.BuildSucceeded && g.PlatformsValidated && g.ProvenanceGenerated && g.SBOMGenerated && g.AttestationVerified
 }
 
-// ProfilePolicy controls promotion and wizard exposure. Full remains present
-// in the schema but disabled until its independent gates are promoted.
+// ProfilePolicy controls compatible promotion and wizard exposure for each
+// profile. Runtime-major candidates still require protected promotion.
 type ProfilePolicy struct {
 	Enabled       bool   `json:"enabled"`
 	WizardDefault bool   `json:"wizardDefault"`
@@ -356,6 +373,36 @@ type SourceOnlyPromotion struct {
 	At                 time.Time `json:"at"`
 }
 
+// UpstreamWorkflowEvidence records the public upstream workflow observation
+// that authorized one compatible hosted promotion. It is kept in the signed
+// catalog so the profile alias does not depend on an ephemeral workflow log.
+type UpstreamWorkflowEvidence struct {
+	Repository     string    `json:"repository"`
+	Workflow       string    `json:"workflow"`
+	RunID          int64     `json:"runId"`
+	RunAttempt     int       `json:"runAttempt"`
+	Event          string    `json:"event"`
+	Branch         string    `json:"branch"`
+	HeadSHA        string    `json:"headSha"`
+	RunConclusion  string    `json:"runConclusion,omitempty"`
+	Conclusion     string    `json:"conclusion"`
+	GateJob        string    `json:"gateJob,omitempty"`
+	TestConclusion string    `json:"testConclusion,omitempty"`
+	CompletedAt    time.Time `json:"completedAt"`
+}
+
+// CompatiblePromotion records automatic movement of a stable profile alias
+// after hosted gates pass for a supported runtime contract. It deliberately
+// does not imply Docker Sandboxes import readback or runtime validation.
+type CompatiblePromotion struct {
+	PackageIndexDigest string                   `json:"packageIndexDigest"`
+	PreviousDigest     string                   `json:"previousDigest,omitempty"`
+	RuntimeContract    string                   `json:"runtimeContract"`
+	Upstream           UpstreamWorkflowEvidence `json:"upstream"`
+	Reason             string                   `json:"reason"`
+	At                 time.Time                `json:"at"`
+}
+
 // Catalog is an append-only publication ledger. Aliases are a projection of
 // the latest successful promotion and can be regenerated from Entries.
 type Catalog struct {
@@ -369,6 +416,7 @@ type Catalog struct {
 	Transitions          []StatusTransition       `json:"transitions"`
 	Acceptances          []PlatformAcceptance     `json:"acceptances,omitempty"`
 	SourceOnlyPromotions []SourceOnlyPromotion    `json:"sourceOnlyPromotions,omitempty"`
+	CompatiblePromotions []CompatiblePromotion    `json:"compatiblePromotions,omitempty"`
 }
 
 // PlanAliasReconciliation compares the observed registry alias with the
@@ -407,9 +455,9 @@ func (c Catalog) PlanAliasReconciliation(profile, observedDigest string) (AliasR
 	return plan, nil
 }
 
-// SourceTupleUnchanged reports whether a source-only upstream movement can
-// reuse the same EPAR recipe/runtime/runner/tool contract. Source digests and
-// package/publication identities intentionally do not participate.
+// SourceTupleUnchanged compares the exact EPAR build/provenance tuple. It is
+// retained for legacy source-only records and nondeterminism detection; v1
+// compatibility itself is defined only by runtime contract and schema.
 func SourceTupleUnchanged(a, b Entry) bool {
 	return a.Profile == b.Profile &&
 		a.Recipe == b.Recipe &&
@@ -419,8 +467,8 @@ func SourceTupleUnchanged(a, b Entry) bool {
 
 // SourceIdentityEqual reports whether the immutable upstream source index and
 // every normalized platform descriptor are unchanged. It is kept separate
-// from SourceTupleUnchanged so auto-advance cannot accidentally rebuild and
-// move an alias for the same complete tuple.
+// from SourceTupleUnchanged so unexplained output nondeterminism for one
+// complete tuple can fail closed.
 func SourceIdentityEqual(a, b Entry) bool {
 	if a.Source.IndexDigest != b.Source.IndexDigest || len(a.Source.PlatformDigests) != len(b.Source.PlatformDigests) {
 		return false
@@ -472,12 +520,93 @@ func ToolsEqual(a, b []ToolDescriptor) bool {
 	return true
 }
 
+func validateUpstreamWorkflowEvidence(profile string, evidence UpstreamWorkflowEvidence, promotedAt time.Time) error {
+	if evidence.Repository != upstreamRepository || evidence.RunID <= 0 || evidence.RunAttempt <= 0 || evidence.Event != "schedule" || evidence.Branch != "master" || evidence.Conclusion != "success" || !revisionPattern.MatchString(evidence.HeadSHA) || evidence.CompletedAt.IsZero() {
+		return errors.New("upstream workflow evidence is incomplete or not a successful scheduled master run")
+	}
+	switch profile {
+	case ProfileAct:
+		if evidence.Workflow != upstreamActWorkflow || evidence.GateJob != upstreamActGateJob || (evidence.TestConclusion != "success" && evidence.TestConclusion != "skipped") {
+			return errors.New("Act upstream evidence does not identify the tag-producing base job")
+		}
+	case ProfileFull:
+		if evidence.Workflow != upstreamFullWorkflow || evidence.GateJob != "four Full copy jobs" || evidence.RunConclusion != "success" {
+			return errors.New("Full upstream evidence does not identify the copy workflow")
+		}
+	default:
+		return fmt.Errorf("unsupported upstream evidence profile %q", profile)
+	}
+	completedAt := evidence.CompletedAt.UTC()
+	promotedAt = promotedAt.UTC()
+	if promotedAt.IsZero() || completedAt.After(promotedAt) || promotedAt.Sub(completedAt) > upstreamEvidenceMaxAge {
+		return errors.New("upstream workflow evidence is stale or newer than the promotion")
+	}
+	return nil
+}
+
+func (c Catalog) validateCompatiblePromotion(promotion CompatiblePromotion) error {
+	targetDigest, err := NormalizeDigest(promotion.PackageIndexDigest)
+	if err != nil {
+		return err
+	}
+	target, ok := c.EntryByDigest(targetDigest)
+	if !ok {
+		return errors.New("compatible promotion references unknown package digest")
+	}
+	if target.Recipe.RuntimeContract != compatibleRuntimeContract || target.Recipe.TemplateSchema != 2 || promotion.RuntimeContract != target.Recipe.RuntimeContract {
+		return errors.New("compatible promotion requires docker-sandboxes-v1 and template schema 2")
+	}
+	if !target.Gates.HostedPass() {
+		return errors.New("compatible promotion target has incomplete hosted gates")
+	}
+	if strings.TrimSpace(promotion.Reason) == "" || promotion.At.IsZero() {
+		return errors.New("compatible promotion requires a reason and timestamp")
+	}
+	if promotion.PreviousDigest != "" {
+		previousDigest, normalizeErr := NormalizeDigest(promotion.PreviousDigest)
+		if normalizeErr != nil {
+			return normalizeErr
+		}
+		if previousDigest == targetDigest {
+			return errors.New("compatible promotion requires distinct package digests")
+		}
+		previous, previousOK := c.EntryByDigest(previousDigest)
+		if !previousOK || previous.Profile != target.Profile || previous.Recipe.RuntimeContract != target.Recipe.RuntimeContract {
+			return errors.New("compatible promotion previous package is missing or runtime-incompatible")
+		}
+	}
+	return validateUpstreamWorkflowEvidence(target.Profile, promotion.Upstream, promotion.At)
+}
+
+func (c Catalog) hasCompatiblePromotion(packageDigest string) bool {
+	for _, promotion := range c.CompatiblePromotions {
+		if promotion.PackageIndexDigest == packageDigest && c.validateCompatiblePromotion(promotion) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Catalog) stableAliasEligible(packageDigest string) (bool, error) {
+	gates, err := c.EffectiveGates(packageDigest)
+	if err != nil {
+		return false, err
+	}
+	if gates.AllPass() {
+		return true, nil
+	}
+	return gates.HostedPass() && c.hasCompatiblePromotion(packageDigest), nil
+}
+
 // Validate performs structural and policy validation. It does not perform
 // network or signature checks; those are intentionally separate publisher
 // gates.
 func (c Catalog) Validate() error {
-	if c.SchemaVersion != CatalogSchemaVersion {
+	if c.SchemaVersion != LegacyCatalogSchemaVersion && c.SchemaVersion != CatalogSchemaVersion {
 		return fmt.Errorf("unsupported prebuilt catalog schema %d", c.SchemaVersion)
+	}
+	if c.SchemaVersion == LegacyCatalogSchemaVersion && len(c.CompatiblePromotions) != 0 {
+		return errors.New("compatible promotions require prebuilt catalog schema 2")
 	}
 	if c.ArtifactKind != CatalogArtifactKind {
 		return fmt.Errorf("unexpected prebuilt catalog artifact kind %q", c.ArtifactKind)
@@ -550,6 +679,16 @@ func (c Catalog) Validate() error {
 			return fmt.Errorf("catalog source-only promotion %d has incomplete effective gates", i)
 		}
 	}
+	compatiblePromotionKeys := make(map[string]struct{}, len(c.CompatiblePromotions))
+	for i, promotion := range c.CompatiblePromotions {
+		if err := c.validateCompatiblePromotion(promotion); err != nil {
+			return fmt.Errorf("catalog compatible promotion %d: %w", i, err)
+		}
+		if _, exists := compatiblePromotionKeys[promotion.PackageIndexDigest]; exists {
+			return fmt.Errorf("duplicate compatible promotion for %s", promotion.PackageIndexDigest)
+		}
+		compatiblePromotionKeys[promotion.PackageIndexDigest] = struct{}{}
+	}
 	for key, alias := range c.Aliases {
 		profile, err := NormalizeProfile(key)
 		if err != nil {
@@ -581,12 +720,19 @@ func (c Catalog) Validate() error {
 		if status != StatusActive {
 			return fmt.Errorf("catalog alias %q points to package with status %s", key, status)
 		}
+		eligible, eligibilityErr := c.stableAliasEligible(alias.PackageIndexDigest)
+		if eligibilityErr != nil {
+			return fmt.Errorf("catalog alias %q eligibility: %w", key, eligibilityErr)
+		}
+		if !eligible {
+			return fmt.Errorf("catalog alias %q points to package without reviewed or compatible hosted promotion evidence", key)
+		}
 	}
 	return nil
 }
 
 func (e Entry) Validate(packageRepository string) error {
-	if e.SchemaVersion != CatalogSchemaVersion {
+	if e.SchemaVersion != EntrySchemaVersion {
 		return fmt.Errorf("unsupported entry schema %d", e.SchemaVersion)
 	}
 	if e.ArtifactKind != CatalogArtifactKind {
@@ -961,6 +1107,51 @@ func (c *Catalog) AppendSourceOnlyPromotion(packageDigest, acceptedFromDigest, r
 	return true, nil
 }
 
+// AppendCompatiblePromotion records hosted-only automatic promotion for a
+// supported runtime contract without claiming Docker Sandboxes readback or
+// runtime validation.
+func (c *Catalog) AppendCompatiblePromotion(packageDigest, previousDigest, reason string, upstream UpstreamWorkflowEvidence, at time.Time) (bool, error) {
+	if c == nil {
+		return false, errors.New("nil prebuilt catalog")
+	}
+	target, ok := c.EntryByDigest(packageDigest)
+	if !ok {
+		return false, errors.New("compatible promotion references unknown package digest")
+	}
+	if previousDigest == "" {
+		if _, exists := c.Aliases[target.Profile]; exists {
+			return false, fmt.Errorf("compatible promotion for %s omitted the current %s alias digest", packageDigest, target.Profile)
+		}
+	} else {
+		alias, exists := c.Aliases[target.Profile]
+		if !exists || alias.PackageIndexDigest != previousDigest {
+			return false, fmt.Errorf("compatible promotion for %s does not match the current %s alias", packageDigest, target.Profile)
+		}
+	}
+	promotion := CompatiblePromotion{
+		PackageIndexDigest: packageDigest,
+		PreviousDigest:     previousDigest,
+		RuntimeContract:    target.Recipe.RuntimeContract,
+		Upstream:           upstream,
+		Reason:             strings.TrimSpace(reason),
+		At:                 at.UTC(),
+	}
+	if err := c.validateCompatiblePromotion(promotion); err != nil {
+		return false, err
+	}
+	for _, existing := range c.CompatiblePromotions {
+		if existing.PackageIndexDigest == packageDigest {
+			if existing.PreviousDigest == previousDigest && existing.Upstream == upstream {
+				return false, nil
+			}
+			return false, fmt.Errorf("compatible promotion for %s already has different evidence", packageDigest)
+		}
+	}
+	c.SchemaVersion = CatalogSchemaVersion
+	c.CompatiblePromotions = append(c.CompatiblePromotions, promotion)
+	return true, nil
+}
+
 // EffectiveStatus applies the append-only transition ledger to an immutable
 // entry. Runtime consumers must use this rather than Entry.Status alone.
 func (c Catalog) EffectiveStatus(digest string) (string, error) {
@@ -1034,7 +1225,7 @@ func (c *Catalog) AppendEntry(entry Entry) (bool, error) {
 		return false, errors.New("nil prebuilt catalog")
 	}
 	if c.SchemaVersion == 0 {
-		c.SchemaVersion = CatalogSchemaVersion
+		c.SchemaVersion = LegacyCatalogSchemaVersion
 	}
 	if c.ArtifactKind == "" {
 		c.ArtifactKind = CatalogArtifactKind
@@ -1081,6 +1272,7 @@ func cloneCatalog(value Catalog) Catalog {
 	clone.Transitions = append([]StatusTransition(nil), value.Transitions...)
 	clone.Acceptances = append([]PlatformAcceptance(nil), value.Acceptances...)
 	clone.SourceOnlyPromotions = append([]SourceOnlyPromotion(nil), value.SourceOnlyPromotions...)
+	clone.CompatiblePromotions = append([]CompatiblePromotion(nil), value.CompatiblePromotions...)
 	clone.Aliases = make(map[string]Alias, len(value.Aliases))
 	for key, alias := range value.Aliases {
 		clone.Aliases[key] = alias
@@ -1114,10 +1306,15 @@ func (c *Catalog) moveAliasInPlace(profile, reference, packageDigest, channel, e
 		if existing, ok := c.Aliases[profile]; !ok || existing.PackageIndexDigest != expectedDigest {
 			return fmt.Errorf("alias %s moved concurrently", profile)
 		}
+	} else if _, exists := c.Aliases[profile]; exists {
+		return fmt.Errorf("alias %s appeared concurrently", profile)
 	}
 	known := false
 	for _, entry := range c.Entries {
 		if entry.PackageIndexDigest == packageDigest {
+			if entry.Profile != profile {
+				return fmt.Errorf("alias %s cannot point to package owned by profile %s", profile, entry.Profile)
+			}
 			status, statusErr := c.EffectiveStatus(packageDigest)
 			if statusErr != nil {
 				return statusErr
@@ -1125,12 +1322,12 @@ func (c *Catalog) moveAliasInPlace(profile, reference, packageDigest, channel, e
 			if status == StatusRevoked || status == StatusCriticalRevoked {
 				return fmt.Errorf("alias %s cannot point to revoked package digest %s", profile, packageDigest)
 			}
-			gates, gateErr := c.EffectiveGates(packageDigest)
-			if gateErr != nil {
-				return gateErr
+			eligible, eligibilityErr := c.stableAliasEligible(packageDigest)
+			if eligibilityErr != nil {
+				return eligibilityErr
 			}
-			if !gates.AllPass() {
-				return fmt.Errorf("alias %s cannot point to package digest %s with incomplete gates", profile, packageDigest)
+			if !eligible {
+				return fmt.Errorf("alias %s cannot point to package digest %s without reviewed or compatible hosted promotion evidence", profile, packageDigest)
 			}
 			if status == StatusCandidate || status == StatusSuperseded {
 				if _, err := c.AppendStatusTransition(packageDigest, StatusActive, "promoted by alias move", now); err != nil {
@@ -1167,6 +1364,7 @@ func (c Catalog) MarshalCanonical() ([]byte, error) {
 	clone.Entries = append([]Entry(nil), c.Entries...)
 	clone.Acceptances = append([]PlatformAcceptance(nil), c.Acceptances...)
 	clone.SourceOnlyPromotions = append([]SourceOnlyPromotion(nil), c.SourceOnlyPromotions...)
+	clone.CompatiblePromotions = append([]CompatiblePromotion(nil), c.CompatiblePromotions...)
 	clone.Aliases = make(map[string]Alias, len(c.Aliases))
 	for key, value := range c.Aliases {
 		clone.Aliases[key] = value
@@ -1189,6 +1387,9 @@ func (c Catalog) MarshalCanonical() ([]byte, error) {
 	})
 	sort.SliceStable(clone.SourceOnlyPromotions, func(i, j int) bool {
 		return clone.SourceOnlyPromotions[i].PackageIndexDigest < clone.SourceOnlyPromotions[j].PackageIndexDigest
+	})
+	sort.SliceStable(clone.CompatiblePromotions, func(i, j int) bool {
+		return clone.CompatiblePromotions[i].PackageIndexDigest < clone.CompatiblePromotions[j].PackageIndexDigest
 	})
 	return json.MarshalIndent(clone, "", "  ")
 }

--- a/internal/prebuilt/catalog_test.go
+++ b/internal/prebuilt/catalog_test.go
@@ -114,7 +114,7 @@ func TestCatalogAcceptanceCompletesCandidateGatesOnlyAfterBothPlatforms(t *testi
 	if gates, err := catalog.EffectiveGates(entry.PackageIndexDigest); err != nil || gates.AllPass() {
 		t.Fatalf("one-platform effective gates = %+v, %v; want incomplete", gates, err)
 	}
-	if err := catalog.MoveAlias(ProfileAct, DefaultPackageRepository+":act-latest", entry.PackageIndexDigest, ChannelStable, "", time.Unix(3, 0)); err == nil || !strings.Contains(err.Error(), "incomplete gates") {
+	if err := catalog.MoveAlias(ProfileAct, DefaultPackageRepository+":act-latest", entry.PackageIndexDigest, ChannelStable, "", time.Unix(3, 0)); err == nil || !strings.Contains(err.Error(), "without reviewed") {
 		t.Fatalf("one-platform alias move error = %v", err)
 	}
 	if _, err := catalog.AppendAcceptance(validAcceptance(entry.PackageIndexDigest, "linux/arm64", 201, 202)); err != nil {
@@ -128,6 +128,50 @@ func TestCatalogAcceptanceCompletesCandidateGatesOnlyAfterBothPlatforms(t *testi
 	}
 	if err := catalog.Validate(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCompatiblePromotionAuthorizesAliasWithoutSynthesizingRuntimeGates(t *testing.T) {
+	entry := validEntry(ProfileAct, "a", StatusCandidate)
+	entry.Gates.ImportReadback = false
+	entry.Gates.RuntimeValidated = false
+	catalog := Catalog{SchemaVersion: LegacyCatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Aliases: map[string]Alias{}}
+	if _, err := catalog.AppendEntry(entry); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := catalog.AppendCompatiblePromotion(entry.PackageIndexDigest, "", "hosted compatible v1", validUpstreamEvidence(ProfileAct, time.Unix(1, 0)), time.Unix(2, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if catalog.SchemaVersion != CatalogSchemaVersion {
+		t.Fatalf("catalog schema = %d, want %d", catalog.SchemaVersion, CatalogSchemaVersion)
+	}
+	if gates, err := catalog.EffectiveGates(entry.PackageIndexDigest); err != nil || gates.ImportReadback || gates.RuntimeValidated {
+		t.Fatalf("compatible promotion synthesized factual gates: %+v, %v", gates, err)
+	}
+	if err := catalog.MoveAlias(ProfileAct, DefaultPackageRepository+":act-latest", entry.PackageIndexDigest, ChannelStable, "", time.Unix(2, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLegacyCatalogRemainsReadableButCannotCarryCompatiblePromotion(t *testing.T) {
+	catalog := Catalog{SchemaVersion: LegacyCatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Entries: []Entry{validEntry(ProfileAct, "a", StatusCandidate)}, Aliases: map[string]Alias{}}
+	if err := catalog.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	catalog.CompatiblePromotions = []CompatiblePromotion{{PackageIndexDigest: catalog.Entries[0].PackageIndexDigest}}
+	if err := catalog.Validate(); err == nil || !strings.Contains(err.Error(), "schema 2") {
+		t.Fatalf("legacy compatible promotion error = %v", err)
+	}
+}
+
+func TestMoveAliasRejectsCrossProfileTarget(t *testing.T) {
+	entry := validEntry(ProfileFull, "a", StatusActive)
+	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true}, ProfileFull: {Enabled: true}}, Entries: []Entry{entry}, Aliases: map[string]Alias{}}
+	if err := catalog.MoveAlias(ProfileAct, DefaultPackageRepository+":act-latest", entry.PackageIndexDigest, ChannelStable, "", time.Unix(2, 0)); err == nil || !strings.Contains(err.Error(), "owned by profile") {
+		t.Fatalf("cross-profile alias error = %v", err)
 	}
 }
 
@@ -241,7 +285,7 @@ func TestCatalogRejectsDuplicateActiveActPlatform(t *testing.T) {
 func validEntry(profile, hexChar, status string) Entry {
 	digest := "sha256:" + strings.Repeat(hexChar, 64)
 	entry := Entry{
-		SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, Profile: profile, Channel: ChannelStable, Status: status,
+		SchemaVersion: EntrySchemaVersion, ArtifactKind: CatalogArtifactKind, Profile: profile, Channel: ChannelStable, Status: status,
 		PackageRepository: DefaultPackageRepository, PackageReference: DefaultPackageRepository + "@" + digest, PackageIndexDigest: digest,
 		Source: SourceDescriptor{Repository: "ghcr.io/catthehacker/ubuntu", SourceTag: profile + "-latest", Reference: "ghcr.io/catthehacker/ubuntu@" + digest, IndexDigest: digest, PlatformDigests: map[string]string{"linux/amd64": digest, "linux/arm64": digest}},
 		Recipe: RecipeDescriptor{Digest: digest, RuntimeContract: "docker-sandboxes-v1", TemplateSchema: 2, RecipeRevision: strings.Repeat(hexChar, 40), SourceLockDigest: digest, ToolDigest: digest},

--- a/internal/prebuilt/publisher.go
+++ b/internal/prebuilt/publisher.go
@@ -19,34 +19,36 @@ const (
 // remain explicit workflow steps. This boundary verifies that the resulting
 // package and evidence can be represented safely in the catalog.
 type PublicationInput struct {
-	Profile            string                `json:"profile"`
-	Channel            string                `json:"channel"`
-	SourceReference    string                `json:"sourceReference"`
-	SourceTag          string                `json:"sourceTag"`
-	PackageRepository  string                `json:"packageRepository"`
-	PackageReference   string                `json:"packageReference"`
-	PackageIndexDigest string                `json:"packageIndexDigest"`
-	PackagePlatforms   []PlatformPublication `json:"packagePlatforms"`
-	Recipe             RecipeDescriptor      `json:"recipe"`
-	Runner             RunnerDescriptor      `json:"runner"`
-	Tools              []ToolDescriptor      `json:"tools"`
-	Evidence           EvidenceDescriptor    `json:"evidence"`
-	Gates              GateResults           `json:"gates"`
-	CandidateID        string                `json:"candidateId,omitempty"`
-	PublishedAt        time.Time             `json:"publishedAt"`
+	Profile            string                   `json:"profile"`
+	Channel            string                   `json:"channel"`
+	SourceReference    string                   `json:"sourceReference"`
+	SourceTag          string                   `json:"sourceTag"`
+	PackageRepository  string                   `json:"packageRepository"`
+	PackageReference   string                   `json:"packageReference"`
+	PackageIndexDigest string                   `json:"packageIndexDigest"`
+	PackagePlatforms   []PlatformPublication    `json:"packagePlatforms"`
+	Recipe             RecipeDescriptor         `json:"recipe"`
+	Runner             RunnerDescriptor         `json:"runner"`
+	Tools              []ToolDescriptor         `json:"tools"`
+	Evidence           EvidenceDescriptor       `json:"evidence"`
+	Gates              GateResults              `json:"gates"`
+	Upstream           UpstreamWorkflowEvidence `json:"upstream"`
+	CandidateID        string                   `json:"candidateId,omitempty"`
+	PublishedAt        time.Time                `json:"publishedAt"`
 }
 
 // PublicationPlan is a deterministic decision after observing the source
 // selector and comparing the new tuple with the catalog. A plan never mutates
 // the catalog until Promote is called.
 type PublicationPlan struct {
-	Entry                Entry  `json:"entry"`
-	Action               string `json:"action"`
-	Reason               string `json:"reason"`
-	ExpectedSourceDigest string `json:"expectedSourceDigest"`
-	ExpectedAliasDigest  string `json:"expectedAliasDigest,omitempty"`
-	SourceReference      string `json:"sourceReference"`
-	ProtectedPromotion   bool   `json:"protectedPromotion,omitempty"`
+	Entry                Entry                    `json:"entry"`
+	Action               string                   `json:"action"`
+	Reason               string                   `json:"reason"`
+	ExpectedSourceDigest string                   `json:"expectedSourceDigest"`
+	ExpectedAliasDigest  string                   `json:"expectedAliasDigest,omitempty"`
+	SourceReference      string                   `json:"sourceReference"`
+	Upstream             UpstreamWorkflowEvidence `json:"upstream"`
+	ProtectedPromotion   bool                     `json:"protectedPromotion,omitempty"`
 }
 
 type Publisher struct {
@@ -63,12 +65,17 @@ func (p Publisher) now() time.Time {
 
 // Plan resolves a mutable upstream source once, validates the package output,
 // and decides whether a catalog entry is a candidate or can auto-advance the
-// profile alias. Recipe/tool/runner changes are always candidates. A source
-// move with an unchanged tuple may auto-advance only when the catalog policy
-// enables that profile and every gate is complete.
+// profile alias. Exact recipe/tool/runner identities are provenance. A package
+// may auto-advance when it preserves the supported runtime contract and both
+// upstream and hosted gates are complete.
 func (p Publisher) Plan(ctx context.Context, catalog Catalog, input PublicationInput) (PublicationPlan, error) {
 	if p.Resolver == nil {
 		return PublicationPlan{}, fmt.Errorf("publisher descriptor resolver is required")
+	}
+	if catalog.SchemaVersion != 0 {
+		if err := catalog.Validate(); err != nil {
+			return PublicationPlan{}, fmt.Errorf("validate publication catalog: %w", err)
+		}
 	}
 	profile, err := NormalizeProfile(input.Profile)
 	if err != nil {
@@ -99,11 +106,14 @@ func (p Publisher) Plan(ctx context.Context, catalog Catalog, input PublicationI
 	if _, err := NormalizeDigest(source.Digest); err != nil {
 		return PublicationPlan{}, err
 	}
-	entry, err := entryFromInput(input, profile, source, p.now())
+	now := p.now()
+	entry, err := entryFromInput(input, profile, source, now)
 	if err != nil {
 		return PublicationPlan{}, err
 	}
-	plan := PublicationPlan{Entry: entry, Action: PlanCandidate, Reason: "new immutable package candidate", ExpectedSourceDigest: source.Digest, SourceReference: input.SourceReference}
+	plan := PublicationPlan{Entry: entry, Action: PlanCandidate, Reason: "new immutable package candidate", ExpectedSourceDigest: source.Digest, SourceReference: input.SourceReference, Upstream: input.Upstream}
+	policy, policyOK := catalog.Policies[profile]
+	autoEligible := policyOK && policy.Enabled && policy.AutoAdvance && entry.Recipe.RuntimeContract == compatibleRuntimeContract && entry.Recipe.TemplateSchema == 2 && entry.Gates.HostedPass() && validateUpstreamWorkflowEvidence(profile, input.Upstream, now) == nil
 	if existing, ok := catalog.EntryByDigest(entry.PackageIndexDigest); ok {
 		status, statusErr := catalog.EffectiveStatus(entry.PackageIndexDigest)
 		if statusErr != nil {
@@ -113,18 +123,38 @@ func (p Publisher) Plan(ctx context.Context, catalog Catalog, input PublicationI
 			return PublicationPlan{}, fmt.Errorf("package index digest %s is %s and cannot be republished; use a new package digest with a changed source or EPAR tuple", entry.PackageIndexDigest, status)
 		}
 		if publicationEntriesEqual(existing, entry) {
-			plan.Action = PlanNoop
-			plan.Reason = "immutable package candidate is already recorded"
 			if alias, aliasOK := catalog.Aliases[profile]; aliasOK {
 				plan.ExpectedAliasDigest = alias.PackageIndexDigest
+				if alias.PackageIndexDigest == entry.PackageIndexDigest {
+					plan.Action = PlanNoop
+					plan.Reason = "package index digest is already active"
+					return plan, nil
+				}
+			}
+			if autoEligible {
+				plan.Action = PlanAdvanceAlias
+				plan.Reason = "existing compatible package passed fresh upstream and hosted gates"
+			} else {
+				plan.Action = PlanNoop
+				plan.Reason = "immutable package candidate is already recorded"
 			}
 			return plan, nil
 		}
 		return PublicationPlan{}, fmt.Errorf("package index digest %s is already recorded with different source, EPAR tuple, evidence, or gates", entry.PackageIndexDigest)
 	}
+	for _, existing := range catalog.Entries {
+		if existing.PackageIndexDigest != entry.PackageIndexDigest && SourceTupleUnchanged(existing, entry) && SourceIdentityEqual(existing, entry) {
+			return PublicationPlan{}, fmt.Errorf("package index digest %s differs from recorded package %s while the complete source and EPAR tuple is unchanged; unexplained package nondeterminism is not promotable", entry.PackageIndexDigest, existing.PackageIndexDigest)
+		}
+	}
 	alias, hasAlias := catalog.Aliases[profile]
 	if !hasAlias {
-		plan.Reason = "first publication requires protected two-platform acceptance"
+		if autoEligible {
+			plan.Action = PlanAdvanceAlias
+			plan.Reason = "first compatible package passed fresh upstream and hosted gates"
+		} else {
+			plan.Reason = "first publication is not eligible for compatible automatic promotion"
+		}
 		return plan, nil
 	}
 	plan.ExpectedAliasDigest = alias.PackageIndexDigest
@@ -140,20 +170,12 @@ func (p Publisher) Plan(ctx context.Context, catalog Catalog, input PublicationI
 		plan.Reason = "package index digest is already active"
 		return plan, nil
 	}
-	unchangedEPARTuple := SourceTupleUnchanged(previous, entry)
-	sourceChanged := !SourceIdentityEqual(previous, entry)
-	if unchangedEPARTuple && !sourceChanged {
+	if SourceTupleUnchanged(previous, entry) && SourceIdentityEqual(previous, entry) {
 		return PublicationPlan{}, fmt.Errorf("package index digest %s differs while the complete source and EPAR tuple is unchanged; protected rebuild is required", entry.PackageIndexDigest)
 	}
-	if policy, ok := catalog.Policies[profile]; ok && policy.Enabled && policy.AutoAdvance && sourceChanged && unchangedEPARTuple && entry.Gates.HostedPass() {
-		baselineGates, gateErr := catalog.EffectiveGates(previous.PackageIndexDigest)
-		if gateErr != nil {
-			return PublicationPlan{}, fmt.Errorf("evaluate accepted source-only baseline: %w", gateErr)
-		}
-		if baselineGates.AllPass() {
-			plan.Action = PlanAdvanceAlias
-			plan.Reason = "upstream source digest changed while an accepted recipe/runtime/runner/tool tuple remained unchanged"
-		}
+	if autoEligible && previous.Recipe.RuntimeContract == entry.Recipe.RuntimeContract {
+		plan.Action = PlanAdvanceAlias
+		plan.Reason = "compatible package passed fresh upstream and hosted gates"
 	}
 	return plan, nil
 }
@@ -191,18 +213,37 @@ func (p Publisher) Promote(ctx context.Context, catalog *Catalog, plan Publicati
 	if p.Resolver == nil {
 		return fmt.Errorf("publisher descriptor resolver is required")
 	}
+	policy, ok := catalog.Policies[entry.Profile]
+	if !ok || !policy.Enabled || !policy.AutoAdvance {
+		return fmt.Errorf("profile %s is no longer enabled for compatible automatic promotion", entry.Profile)
+	}
+	if entry.Recipe.RuntimeContract != compatibleRuntimeContract || entry.Recipe.TemplateSchema != 2 || !entry.Gates.HostedPass() {
+		return fmt.Errorf("package %s is not eligible for compatible automatic promotion", entry.PackageIndexDigest)
+	}
+	if plan.ExpectedSourceDigest != entry.Source.IndexDigest {
+		return fmt.Errorf("promotion plan source digest does not match package provenance")
+	}
+	if err := validateUpstreamWorkflowEvidence(entry.Profile, plan.Upstream, p.now()); err != nil {
+		return fmt.Errorf("upstream promotion evidence: %w", err)
+	}
 	if _, err := RecheckUnchanged(ctx, p.Resolver, plan.SourceReference, plan.ExpectedSourceDigest); err != nil {
 		return err
 	}
 	// Build a complete candidate state first. A source or alias race must not
 	// leave an active entry that the moving alias never references.
 	clone := cloneCatalog(*catalog)
-	if _, err := clone.AppendEntry(entry); err != nil {
-		return err
+	if existing, found := clone.EntryByDigest(entry.PackageIndexDigest); found {
+		if !publicationEntriesEqual(existing, entry) {
+			return fmt.Errorf("existing package %s differs from compatible promotion plan", entry.PackageIndexDigest)
+		}
+	} else {
+		if _, err := clone.AppendEntry(entry); err != nil {
+			return err
+		}
 	}
 	profile := entry.Profile
 	previousDigest := plan.ExpectedAliasDigest
-	if _, err := clone.AppendSourceOnlyPromotion(entry.PackageIndexDigest, previousDigest, plan.Reason, p.now()); err != nil {
+	if _, err := clone.AppendCompatiblePromotion(entry.PackageIndexDigest, previousDigest, plan.Reason, plan.Upstream, p.now()); err != nil {
 		return err
 	}
 	tag, _ := AliasTag(profile)
@@ -214,12 +255,10 @@ func (p Publisher) Promote(ctx context.Context, catalog *Catalog, plan Publicati
 }
 
 // PromoteProtected performs an explicitly approved manual promotion of a
-// candidate produced by Plan. It is deliberately separate from Promote so a
-// recipe/runner/tool change can never auto-advance an alias merely because all
-// build gates happen to pass. The same mutable-source recheck and alias CAS
-// rules apply. Full is the one bootstrap exception: its first independently
-// accepted protected promotion enables its stable policy atomically with the
-// alias move, so it cannot become a wizard default before the gates pass.
+// candidate produced by Plan. It remains the runtime-major and break-glass
+// path and requires factual Docker Sandboxes acceptance. The same mutable-
+// source recheck and alias CAS rules apply. Legacy catalogs may still use the
+// Full bootstrap behavior below.
 func (p Publisher) PromoteProtected(ctx context.Context, catalog *Catalog, plan PublicationPlan) error {
 	if catalog == nil {
 		return fmt.Errorf("nil prebuilt catalog")
@@ -312,7 +351,7 @@ func entryFromInput(input PublicationInput, profile string, source ResolvedRefer
 		sourceDescriptor.PlatformDigests[platform] = descriptor.Digest
 	}
 	entry := Entry{
-		SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, Profile: profile, Channel: input.Channel, Status: StatusCandidate,
+		SchemaVersion: EntrySchemaVersion, ArtifactKind: CatalogArtifactKind, Profile: profile, Channel: input.Channel, Status: StatusCandidate,
 		PackageRepository: input.PackageRepository, PackageReference: input.PackageReference, PackageIndexDigest: packageDigest,
 		Source: sourceDescriptor, Recipe: input.Recipe, Runner: input.Runner, Tools: input.Tools, Platforms: input.PackagePlatforms,
 		Evidence: input.Evidence, Gates: input.Gates, PublishedAt: input.PublishedAt, CandidateID: input.CandidateID,

--- a/internal/prebuilt/publisher_test.go
+++ b/internal/prebuilt/publisher_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestPublisherAutoAdvancesOnlyForSourceOnlyChange(t *testing.T) {
+func TestPublisherAutoAdvancesCompatibleV1Change(t *testing.T) {
 	oldDigest := "sha256:" + strings.Repeat("a", 64)
 	newDigest := "sha256:" + strings.Repeat("b", 64)
 	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(newDigest), sourceObservation(newDigest)}}
@@ -43,12 +43,13 @@ func TestPublisherAutoAdvancesOnlyForSourceOnlyChange(t *testing.T) {
 func TestPublisherNoopForCompleteTuple(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
 	previous := validEntry(ProfileAct, "a", StatusActive)
-	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: digest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
 	input := publicationInput(digest)
+	input.Gates = previous.Gates
+	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: digest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
 	input.SourceReference = "ghcr.io/catthehacker/ubuntu:act-latest"
 	input.SourceTag = "act-latest"
 	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(digest)}}
-	plan, err := (Publisher{Resolver: resolver}).Plan(context.Background(), catalog, input)
+	plan, err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +71,7 @@ func TestPublisherAutoAdvancesWhenUpstreamIndexChanges(t *testing.T) {
 	input.SourceTag = "act-latest"
 	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(newDigest)}}
 	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: oldDigest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
-	plan, err := (Publisher{Resolver: resolver}).Plan(context.Background(), catalog, input)
+	plan, err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +80,7 @@ func TestPublisherAutoAdvancesWhenUpstreamIndexChanges(t *testing.T) {
 	}
 }
 
-func TestPublisherLeavesRecipeChangeAsCandidate(t *testing.T) {
+func TestPublisherAutoAdvancesRecipeChangeWithinV1(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
 	previous := validEntry(ProfileAct, "a", StatusActive)
 	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: digest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
@@ -90,12 +91,67 @@ func TestPublisherLeavesRecipeChangeAsCandidate(t *testing.T) {
 	input.Recipe.Digest = "sha256:" + strings.Repeat("b", 64)
 	input.PackageIndexDigest = "sha256:" + strings.Repeat("c", 64)
 	input.PackageReference = DefaultPackageRepository + "@" + input.PackageIndexDigest
-	plan, err := (Publisher{Resolver: resolver}).Plan(context.Background(), catalog, input)
+	plan, err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Action != PlanAdvanceAlias {
+		t.Fatalf("action = %q, want compatible v1 alias advancement", plan.Action)
+	}
+}
+
+func TestPublisherRuntimeMajorChangeRemainsCandidate(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	previous := validEntry(ProfileAct, "a", StatusActive)
+	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: digest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
+	input := publicationInput(digest)
+	input.Recipe.RuntimeContract = "docker-sandboxes-v2"
+	input.PackageIndexDigest = "sha256:" + strings.Repeat("c", 64)
+	input.PackageReference = DefaultPackageRepository + "@" + input.PackageIndexDigest
+	plan, err := (Publisher{Resolver: &sequenceResolver{observations: []ResolvedReference{sourceObservation(digest)}}, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if plan.Action != PlanCandidate {
-		t.Fatalf("action = %q, want candidate", plan.Action)
+		t.Fatalf("runtime v2 action = %q, want candidate", plan.Action)
+	}
+}
+
+func TestPublisherTreatsV1ProvenanceIdentityChangesAsCompatible(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	changedDigest := "sha256:" + strings.Repeat("b", 64)
+	cases := []struct {
+		name string
+		edit func(*PublicationInput)
+	}{
+		{name: "recipe helper", edit: func(input *PublicationInput) { input.Recipe.Digest = changedDigest }},
+		{name: "recipe revision", edit: func(input *PublicationInput) { input.Recipe.RecipeRevision = strings.Repeat("b", 40) }},
+		{name: "source lock", edit: func(input *PublicationInput) { input.Recipe.SourceLockDigest = changedDigest }},
+		{name: "tool lock", edit: func(input *PublicationInput) {
+			input.Recipe.ToolDigest = changedDigest
+			input.Tools[0].Digest = changedDigest
+		}},
+		{name: "runner", edit: func(input *PublicationInput) {
+			input.Runner.Version = "2.999.0"
+			input.Runner.AssetDigests["linux/amd64"] = changedDigest
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			previous := validEntry(ProfileAct, "a", StatusActive)
+			catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: digest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
+			input := publicationInput(digest)
+			input.PackageIndexDigest = "sha256:" + strings.Repeat("c", 64)
+			input.PackageReference = DefaultPackageRepository + "@" + input.PackageIndexDigest
+			tc.edit(&input)
+			plan, err := (Publisher{Resolver: &sequenceResolver{observations: []ResolvedReference{sourceObservation(digest)}}, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.Action != PlanAdvanceAlias {
+				t.Fatalf("action = %q, want compatible v1 advancement", plan.Action)
+			}
+		})
 	}
 }
 
@@ -153,7 +209,7 @@ func TestPublisherProtectedPromotionBootstrapsAcceptedFull(t *testing.T) {
 	if err := publisher.Promote(context.Background(), &catalog, plan); err != nil {
 		t.Fatal(err)
 	}
-	if err := publisher.PromoteProtected(context.Background(), &catalog, plan); err == nil || !strings.Contains(err.Error(), "acceptance") {
+	if err := publisher.PromoteProtected(context.Background(), &catalog, plan); err == nil || (!strings.Contains(err.Error(), "acceptance") && !strings.Contains(err.Error(), "incomplete")) {
 		t.Fatalf("unaccepted Full promotion error = %v", err)
 	}
 	if _, err := catalog.AppendAcceptance(validAcceptanceForProfile(ProfileFull, digest, "linux/amd64", 101, 102)); err != nil {
@@ -176,6 +232,28 @@ func TestPublisherProtectedPromotionBootstrapsAcceptedFull(t *testing.T) {
 	}
 }
 
+func TestPublisherAutomaticallyPromotesCompatibleFull(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	input := publicationInput(digest)
+	input.Profile = ProfileFull
+	input.SourceReference = "ghcr.io/catthehacker/ubuntu:full-latest"
+	input.SourceTag = "full-latest"
+	input.Upstream = validUpstreamEvidence(ProfileFull, time.Unix(1, 0))
+	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(digest), sourceObservation(digest)}}
+	catalog := Catalog{SchemaVersion: LegacyCatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileFull: {Enabled: true, WizardDefault: true, AutoAdvance: true}}, Aliases: map[string]Alias{}}
+	publisher := Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}
+	plan, err := publisher.Plan(context.Background(), catalog, input)
+	if err != nil || plan.Action != PlanAdvanceAlias {
+		t.Fatalf("Full plan = %#v, %v", plan, err)
+	}
+	if err := publisher.Promote(context.Background(), &catalog, plan); err != nil {
+		t.Fatal(err)
+	}
+	if catalog.Aliases[ProfileFull].PackageIndexDigest != digest || len(catalog.CompatiblePromotions) != 1 {
+		t.Fatalf("Full automatic promotion = %#v", catalog)
+	}
+}
+
 func TestPublisherProtectedPromotionRejectsIncompleteCandidate(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
 	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(digest)}}
@@ -184,7 +262,7 @@ func TestPublisherProtectedPromotionRejectsIncompleteCandidate(t *testing.T) {
 	input.SourceReference = resolver.observations[0].Reference
 	input.SourceTag = "act-latest"
 	input.Gates.RuntimeValidated = false
-	plan, err := (Publisher{Resolver: resolver}).Plan(context.Background(), catalog, input)
+	plan, err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,12 +327,13 @@ func TestPublisherRejectsRebuildWithSameCompleteTuple(t *testing.T) {
 	}
 }
 
-func TestPublisherRerunOfUnpromotedCandidateIsNoop(t *testing.T) {
+func TestPublisherReevaluatesAndPromotesExistingCompatibleCandidate(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
 	input := publicationInput(digest)
+	input.Upstream = UpstreamWorkflowEvidence{}
 	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(digest), sourceObservation(digest)}}
 	publisher := Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}
-	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository}
+	catalog := Catalog{SchemaVersion: LegacyCatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Aliases: map[string]Alias{}}
 	first, err := publisher.Plan(context.Background(), catalog, input)
 	if err != nil || first.Action != PlanCandidate {
 		t.Fatalf("first plan = %#v, %v", first, err)
@@ -262,12 +341,45 @@ func TestPublisherRerunOfUnpromotedCandidateIsNoop(t *testing.T) {
 	if err := publisher.Promote(context.Background(), &catalog, first); err != nil {
 		t.Fatal(err)
 	}
+	input.Upstream = validUpstreamEvidence(ProfileAct, time.Unix(1, 0))
 	second, err := publisher.Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second.Action != PlanNoop {
+	if second.Action != PlanAdvanceAlias {
 		t.Fatalf("rerun action = %q, reason %s", second.Action, second.Reason)
+	}
+	if err := publisher.Promote(context.Background(), &catalog, second); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Entries) != 1 || catalog.Aliases[ProfileAct].PackageIndexDigest != digest || catalog.SchemaVersion != CatalogSchemaVersion {
+		t.Fatalf("reevaluated catalog = %#v", catalog)
+	}
+}
+
+func TestPublisherPromotionRechecksAutoAdvancePolicy(t *testing.T) {
+	oldDigest := "sha256:" + strings.Repeat("a", 64)
+	newDigest := "sha256:" + strings.Repeat("b", 64)
+	previous := validEntry(ProfileAct, "a", StatusActive)
+	previous.PackageIndexDigest = oldDigest
+	previous.PackageReference = DefaultPackageRepository + "@" + oldDigest
+	previous.Source.IndexDigest = oldDigest
+	previous.Source.Reference = previous.Source.Repository + "@" + oldDigest
+	catalog := Catalog{SchemaVersion: CatalogSchemaVersion, ArtifactKind: CatalogArtifactKind, PackageRepository: DefaultPackageRepository, Policies: map[string]ProfilePolicy{ProfileAct: {Enabled: true, AutoAdvance: true}}, Entries: []Entry{previous}, Aliases: map[string]Alias{ProfileAct: {Profile: ProfileAct, PackageIndexDigest: oldDigest, Tag: "act-latest", Reference: DefaultPackageRepository + ":act-latest", Channel: ChannelStable, Status: StatusActive}}}
+	resolver := &sequenceResolver{observations: []ResolvedReference{sourceObservation(newDigest), sourceObservation(newDigest)}}
+	publisher := Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}
+	plan, err := publisher.Plan(context.Background(), catalog, publicationInput(newDigest))
+	if err != nil || plan.Action != PlanAdvanceAlias {
+		t.Fatalf("plan = %#v, %v", plan, err)
+	}
+	policy := catalog.Policies[ProfileAct]
+	policy.AutoAdvance = false
+	catalog.Policies[ProfileAct] = policy
+	if err := publisher.Promote(context.Background(), &catalog, plan); err == nil || !strings.Contains(err.Error(), "no longer enabled") {
+		t.Fatalf("policy race error = %v", err)
+	}
+	if _, exists := catalog.EntryByDigest(newDigest); exists || catalog.Aliases[ProfileAct].PackageIndexDigest != oldDigest {
+		t.Fatal("policy race mutated the catalog")
 	}
 }
 
@@ -328,11 +440,11 @@ func TestPublisherPromotionRejectsSourceMove(t *testing.T) {
 	input := publicationInput(newDigest)
 	input.SourceReference = resolver.observations[0].Reference
 	input.SourceTag = "act-latest"
-	plan, err := (Publisher{Resolver: resolver}).Plan(context.Background(), catalog, input)
+	plan, err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := (Publisher{Resolver: resolver}).Promote(context.Background(), &catalog, plan); err == nil {
+	if err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Promote(context.Background(), &catalog, plan); err == nil {
 		t.Fatal("source race unexpectedly promoted alias")
 	}
 	if got := catalog.Aliases[ProfileAct].PackageIndexDigest; got != oldDigest {
@@ -356,7 +468,7 @@ func TestPublisherAliasRaceLeavesCatalogUnchanged(t *testing.T) {
 	input := publicationInput(newDigest)
 	input.SourceReference = resolver.observations[0].Reference
 	input.SourceTag = "act-latest"
-	plan, err := (Publisher{Resolver: resolver}).Plan(context.Background(), catalog, input)
+	plan, err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Plan(context.Background(), catalog, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +477,7 @@ func TestPublisherAliasRaceLeavesCatalogUnchanged(t *testing.T) {
 	racedAlias.PackageIndexDigest = "sha256:" + strings.Repeat("c", 64)
 	catalog.Aliases[ProfileAct] = racedAlias
 	before := len(catalog.Entries)
-	if err := (Publisher{Resolver: resolver}).Promote(context.Background(), &catalog, plan); err == nil {
+	if err := (Publisher{Resolver: resolver, Now: func() time.Time { return time.Unix(2, 0) }}).Promote(context.Background(), &catalog, plan); err == nil {
 		t.Fatal("alias race unexpectedly promoted")
 	}
 	if len(catalog.Entries) != before {
@@ -396,10 +508,26 @@ func TestStatusTransitionsKeepImmutableEntryAndExposeEffectiveStatus(t *testing.
 }
 
 func publicationInput(packageDigest string) PublicationInput {
+	entry := validEntry(ProfileAct, "a", StatusActive)
+	gates := entry.Gates
+	gates.ImportReadback = false
+	gates.RuntimeValidated = false
 	return PublicationInput{
 		Profile: ProfileAct, Channel: ChannelStable, SourceReference: "ghcr.io/catthehacker/ubuntu:act-latest", SourceTag: "act-latest", PackageRepository: DefaultPackageRepository, PackageReference: DefaultPackageRepository + "@" + packageDigest, PackageIndexDigest: packageDigest,
-		PackagePlatforms: []PlatformPublication{{Platform: "linux/amd64", PackageManifestDigest: packageDigest, SourceManifestDigest: packageDigest, Validated: true}, {Platform: "linux/arm64", PackageManifestDigest: packageDigest, SourceManifestDigest: packageDigest, Validated: true}}, Recipe: validEntry(ProfileAct, "a", StatusActive).Recipe, Runner: validEntry(ProfileAct, "a", StatusActive).Runner, Tools: validEntry(ProfileAct, "a", StatusActive).Tools, Evidence: validEntry(ProfileAct, "a", StatusActive).Evidence, Gates: validEntry(ProfileAct, "a", StatusActive).Gates, PublishedAt: time.Unix(2, 0),
+		PackagePlatforms: []PlatformPublication{{Platform: "linux/amd64", PackageManifestDigest: packageDigest, SourceManifestDigest: packageDigest, Validated: true}, {Platform: "linux/arm64", PackageManifestDigest: packageDigest, SourceManifestDigest: packageDigest, Validated: true}}, Recipe: entry.Recipe, Runner: entry.Runner, Tools: entry.Tools, Evidence: entry.Evidence, Gates: gates, Upstream: validUpstreamEvidence(ProfileAct, time.Unix(1, 0)), PublishedAt: time.Unix(2, 0),
 	}
+}
+
+func validUpstreamEvidence(profile string, completedAt time.Time) UpstreamWorkflowEvidence {
+	evidence := UpstreamWorkflowEvidence{Repository: upstreamRepository, RunID: 123, RunAttempt: 1, Event: "schedule", Branch: "master", HeadSHA: strings.Repeat("a", 40), RunConclusion: "success", Conclusion: "success", TestConclusion: "skipped", CompletedAt: completedAt.UTC()}
+	if profile == ProfileFull {
+		evidence.Workflow = upstreamFullWorkflow
+		evidence.GateJob = "four Full copy jobs"
+	} else {
+		evidence.Workflow = upstreamActWorkflow
+		evidence.GateJob = upstreamActGateJob
+	}
+	return evidence
 }
 
 type sequenceResolver struct {

--- a/internal/prebuilt/upstream.go
+++ b/internal/prebuilt/upstream.go
@@ -1,0 +1,241 @@
+package prebuilt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const defaultGitHubAPI = "https://api.github.com"
+
+type UpstreamGateResult struct {
+	Eligible bool                     `json:"eligible"`
+	Reason   string                   `json:"reason"`
+	Evidence UpstreamWorkflowEvidence `json:"evidence,omitempty"`
+}
+
+type UpstreamGateClient struct {
+	HTTPClient *http.Client
+	BaseURL    string
+	Token      string
+	Now        func() time.Time
+}
+
+type upstreamWorkflowRun struct {
+	ID         int64     `json:"id"`
+	RunAttempt int       `json:"run_attempt"`
+	Event      string    `json:"event"`
+	Status     string    `json:"status"`
+	Conclusion string    `json:"conclusion"`
+	HeadBranch string    `json:"head_branch"`
+	HeadSHA    string    `json:"head_sha"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type upstreamWorkflowRunsResponse struct {
+	WorkflowRuns []upstreamWorkflowRun `json:"workflow_runs"`
+}
+
+type upstreamWorkflowStep struct {
+	Name       string `json:"name"`
+	Conclusion string `json:"conclusion"`
+}
+
+type upstreamWorkflowJob struct {
+	Name       string                 `json:"name"`
+	Status     string                 `json:"status"`
+	Conclusion string                 `json:"conclusion"`
+	Steps      []upstreamWorkflowStep `json:"steps"`
+}
+
+type upstreamWorkflowJobsResponse struct {
+	Jobs []upstreamWorkflowJob `json:"jobs"`
+}
+
+func (c UpstreamGateClient) now() time.Time {
+	if c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (c UpstreamGateClient) endpoint(path string) string {
+	base := strings.TrimRight(strings.TrimSpace(c.BaseURL), "/")
+	if base == "" {
+		base = defaultGitHubAPI
+	}
+	return base + path
+}
+
+func (c UpstreamGateClient) getJSON(ctx context.Context, path string, target any) error {
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	token := strings.TrimSpace(c.Token)
+	for attempt := 1; attempt <= 3; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint(path), nil)
+		if err != nil {
+			return err
+		}
+		request.Header.Set("Accept", "application/vnd.github+json")
+		request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		request.Header.Set("User-Agent", "epar-prebuilt-publisher")
+		if token != "" {
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+		response, requestErr := client.Do(request)
+		if requestErr != nil {
+			if attempt == 3 {
+				return requestErr
+			}
+			continue
+		}
+		if response.StatusCode == http.StatusOK {
+			decodeErr := json.NewDecoder(response.Body).Decode(target)
+			response.Body.Close()
+			if decodeErr != nil {
+				return fmt.Errorf("decode GitHub API %s: %w", path, decodeErr)
+			}
+			return nil
+		}
+		status := response.Status
+		statusCode := response.StatusCode
+		response.Body.Close()
+		if token != "" && (statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden) {
+			// Public Actions metadata may reject a repository-scoped GITHUB_TOKEN.
+			// Retry the same GET anonymously before requiring a dedicated token.
+			token = ""
+			continue
+		}
+		if statusCode != http.StatusTooManyRequests && statusCode < http.StatusInternalServerError || attempt == 3 {
+			return fmt.Errorf("GitHub API %s returned %s", path, status)
+		}
+	}
+	return fmt.Errorf("GitHub API %s exhausted retries", path)
+}
+
+func (c UpstreamGateClient) Evaluate(ctx context.Context, profile string) (UpstreamGateResult, error) {
+	profile, err := NormalizeProfile(profile)
+	if err != nil {
+		return UpstreamGateResult{}, err
+	}
+	workflow := upstreamActWorkflow
+	if profile == ProfileFull {
+		workflow = upstreamFullWorkflow
+	}
+	runsPath := "/repos/" + upstreamRepository + "/actions/workflows/" + url.PathEscape(workflow) + "/runs?branch=master&per_page=20"
+	var runs upstreamWorkflowRunsResponse
+	if err := c.getJSON(ctx, runsPath, &runs); err != nil {
+		return UpstreamGateResult{}, err
+	}
+	var tagMoving []upstreamWorkflowRun
+	for _, run := range runs.WorkflowRuns {
+		if run.Event == "schedule" || run.Event == "workflow_dispatch" {
+			tagMoving = append(tagMoving, run)
+		}
+	}
+	if len(tagMoving) == 0 {
+		return UpstreamGateResult{Reason: "no tag-moving upstream workflow run was found"}, nil
+	}
+	sort.Slice(tagMoving, func(i, j int) bool { return tagMoving[i].CreatedAt.After(tagMoving[j].CreatedAt) })
+	run := tagMoving[0]
+	if run.ID <= 0 || run.RunAttempt <= 0 || run.HeadBranch != "master" || !revisionPattern.MatchString(run.HeadSHA) || run.CreatedAt.IsZero() || run.UpdatedAt.IsZero() {
+		return UpstreamGateResult{}, errors.New("newest upstream workflow run metadata is malformed")
+	}
+	if run.Event != "schedule" {
+		return UpstreamGateResult{Reason: "newest tag-moving upstream run was not scheduled"}, nil
+	}
+	completedAt := run.UpdatedAt.UTC()
+	if run.Status != "completed" || completedAt.IsZero() || completedAt.After(c.now()) || c.now().Sub(completedAt) > upstreamEvidenceMaxAge {
+		return UpstreamGateResult{Reason: "newest scheduled upstream run is incomplete or older than 10 days"}, nil
+	}
+	jobsPath := fmt.Sprintf("/repos/%s/actions/runs/%d/attempts/%d/jobs?per_page=100", upstreamRepository, run.ID, run.RunAttempt)
+	var jobs upstreamWorkflowJobsResponse
+	if err := c.getJSON(ctx, jobsPath, &jobs); err != nil {
+		return UpstreamGateResult{}, err
+	}
+	gateJob := ""
+	gateConclusion := "success"
+	testConclusion := ""
+	if profile == ProfileFull {
+		if run.Conclusion != "success" || len(jobs.Jobs) != 4 {
+			return UpstreamGateResult{Reason: "Full copy workflow or expected four-job matrix was not green"}, nil
+		}
+		expectedJobs := map[string]int{upstreamFull24Job: 2, upstreamFull22Job: 1, upstreamFull20Job: 1}
+		for _, job := range jobs.Jobs {
+			if job.Status != "completed" || job.Conclusion != "success" || !stepSucceeded(job.Steps, "Login to GitHub Container Registry") {
+				return UpstreamGateResult{Reason: "Full copy workflow contained an incomplete GHCR copy job"}, nil
+			}
+			expectedJobs[job.Name]--
+		}
+		for _, remaining := range expectedJobs {
+			if remaining != 0 {
+				return UpstreamGateResult{Reason: "Full copy workflow job identities did not match the expected full-latest matrix"}, nil
+			}
+		}
+		gateJob = "four Full copy jobs"
+	} else {
+		matches := 0
+		for _, job := range jobs.Jobs {
+			if job.Name != upstreamActGateJob {
+				continue
+			}
+			matches++
+			if job.Status != "completed" || job.Conclusion != "success" || !stepSucceeded(job.Steps, "Build and push ubuntu:act-24.04") {
+				return UpstreamGateResult{Reason: "Act tag-producing job or push step was not green"}, nil
+			}
+			testConclusion = stepConclusion(job.Steps, "Run cd act/")
+			if testConclusion != "success" && testConclusion != "skipped" {
+				return UpstreamGateResult{Reason: "Act tag-producing job did not contain its expected test path"}, nil
+			}
+		}
+		if matches != 1 {
+			return UpstreamGateResult{Reason: "Act workflow did not contain exactly one tag-producing job"}, nil
+		}
+		gateJob = upstreamActGateJob
+	}
+	evidence := UpstreamWorkflowEvidence{
+		Repository:     upstreamRepository,
+		Workflow:       workflow,
+		RunID:          run.ID,
+		RunAttempt:     run.RunAttempt,
+		Event:          run.Event,
+		Branch:         run.HeadBranch,
+		HeadSHA:        run.HeadSHA,
+		RunConclusion:  run.Conclusion,
+		Conclusion:     gateConclusion,
+		GateJob:        gateJob,
+		TestConclusion: testConclusion,
+		CompletedAt:    completedAt,
+	}
+	if err := validateUpstreamWorkflowEvidence(profile, evidence, c.now()); err != nil {
+		return UpstreamGateResult{}, err
+	}
+	return UpstreamGateResult{Eligible: true, Reason: "fresh upstream tag-producing workflow evidence is green", Evidence: evidence}, nil
+}
+
+func stepSucceeded(steps []upstreamWorkflowStep, name string) bool {
+	for _, step := range steps {
+		if step.Name == name && step.Conclusion == "success" {
+			return true
+		}
+	}
+	return false
+}
+
+func stepConclusion(steps []upstreamWorkflowStep, name string) string {
+	for _, step := range steps {
+		if step.Name == name {
+			return step.Conclusion
+		}
+	}
+	return ""
+}

--- a/internal/prebuilt/upstream_test.go
+++ b/internal/prebuilt/upstream_test.go
@@ -1,0 +1,179 @@
+package prebuilt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUpstreamGateActUsesTagProducingJobDespiteUnrelatedFailures(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	runs := upstreamRunsFixture(now, "schedule", "completed", "failure")
+	jobs := `{"jobs":[{"name":"Build base 24.04","status":"completed","conclusion":"success","steps":[{"name":"Build and push ubuntu:act-24.04","conclusion":"success"},{"name":"Run cd act/","conclusion":"skipped"}]},{"name":"Unrelated flavor","status":"completed","conclusion":"failure","steps":[]}]}`
+	client, closeServer := upstreamFixtureClient(t, runs, jobs, http.StatusOK)
+	defer closeServer()
+
+	result, err := client.Evaluate(context.Background(), ProfileAct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Eligible || result.Evidence.RunConclusion != "failure" || result.Evidence.GateJob != upstreamActGateJob {
+		t.Fatalf("Act gate result = %#v", result)
+	}
+}
+
+func TestUpstreamGateFullRequiresGreenFourJobCopyMatrix(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	runs := upstreamRunsFixture(now, "schedule", "completed", "success")
+	job := func(name string) string {
+		return fmt.Sprintf(`{"name":%q,"status":"completed","conclusion":"success","steps":[{"name":"Login to GitHub Container Registry","conclusion":"success"}]}`, name)
+	}
+	jobs := `{"jobs":[` + strings.Join([]string{job(upstreamFull24Job), job(upstreamFull24Job), job(upstreamFull22Job), job(upstreamFull20Job)}, ",") + `]}`
+	client, closeServer := upstreamFixtureClient(t, runs, jobs, http.StatusOK)
+	defer closeServer()
+
+	result, err := client.Evaluate(context.Background(), ProfileFull)
+	if err != nil || !result.Eligible {
+		t.Fatalf("Full gate = %#v, %v", result, err)
+	}
+}
+
+func TestUpstreamGateNonGreenStatesSkipPublication(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		runs string
+		jobs string
+	}{
+		{name: "newer manual", runs: fmt.Sprintf(`{"workflow_runs":[{"id":99,"run_attempt":1,"event":"workflow_dispatch","status":"completed","conclusion":"success","head_branch":"master","head_sha":"%s","created_at":"%s","updated_at":"%s"},{"id":42,"run_attempt":1,"event":"schedule","status":"completed","conclusion":"success","head_branch":"master","head_sha":"%s","created_at":"%s","updated_at":"%s"}]}`, strings.Repeat("a", 40), now.Add(-time.Hour).Format(time.RFC3339), now.Add(-time.Hour).Format(time.RFC3339), strings.Repeat("b", 40), now.Add(-2*time.Hour).Format(time.RFC3339), now.Add(-2*time.Hour).Format(time.RFC3339)), jobs: `{"jobs":[]}`},
+		{name: "pending", runs: upstreamRunsFixture(now, "schedule", "in_progress", ""), jobs: `{"jobs":[]}`},
+		{name: "stale", runs: upstreamRunsFixture(now.Add(-11*24*time.Hour), "schedule", "completed", "success"), jobs: `{"jobs":[]}`},
+		{name: "missing job", runs: upstreamRunsFixture(now, "schedule", "completed", "success"), jobs: `{"jobs":[]}`},
+		{name: "missing push step", runs: upstreamRunsFixture(now, "schedule", "completed", "success"), jobs: `{"jobs":[{"name":"Build base 24.04","status":"completed","conclusion":"success","steps":[]}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, closeServer := upstreamFixtureClient(t, tc.runs, tc.jobs, http.StatusOK)
+			defer closeServer()
+			result, err := client.Evaluate(context.Background(), ProfileAct)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Eligible || result.Reason == "" {
+				t.Fatalf("non-green gate = %#v", result)
+			}
+		})
+	}
+}
+
+func TestUpstreamEvidenceFreshnessBoundary(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name      string
+		completed time.Time
+		wantError bool
+	}{
+		{name: "exactly ten days", completed: now.Add(-10 * 24 * time.Hour)},
+		{name: "just stale", completed: now.Add(-10*24*time.Hour - time.Second), wantError: true},
+		{name: "future", completed: now.Add(time.Second), wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateUpstreamWorkflowEvidence(ProfileAct, validUpstreamEvidence(ProfileAct, tc.completed), now)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("freshness error = %v, wantError=%v", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestUpstreamGateAPIFailuresFailClosed(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	for _, status := range []int{http.StatusForbidden, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			client, closeServer := upstreamFixtureClient(t, upstreamRunsFixture(now, "schedule", "completed", "success"), `{"jobs":[]}`, status)
+			defer closeServer()
+			if _, err := client.Evaluate(context.Background(), ProfileAct); err == nil {
+				t.Fatalf("HTTP %d unexpectedly passed", status)
+			}
+		})
+	}
+	client, closeServer := upstreamFixtureClient(t, `{`, `{"jobs":[]}`, http.StatusOK)
+	defer closeServer()
+	if _, err := client.Evaluate(context.Background(), ProfileAct); err == nil {
+		t.Fatal("malformed response unexpectedly passed")
+	}
+}
+
+func TestUpstreamGateFallsBackToAnonymousGETForPublicMetadata(t *testing.T) {
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	runs := upstreamRunsFixture(now, "schedule", "completed", "failure")
+	jobs := `{"jobs":[{"name":"Build base 24.04","status":"completed","conclusion":"success","steps":[{"name":"Build and push ubuntu:act-24.04","conclusion":"success"},{"name":"Run cd act/","conclusion":"skipped"}]}]}`
+	authenticated := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet {
+			t.Fatalf("method = %s", request.Method)
+		}
+		if request.Header.Get("Authorization") != "" {
+			authenticated++
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "/actions/runs/") {
+			_, _ = response.Write([]byte(jobs))
+		} else {
+			_, _ = response.Write([]byte(runs))
+		}
+	}))
+	defer server.Close()
+	result, err := (UpstreamGateClient{HTTPClient: server.Client(), BaseURL: server.URL, Token: "repository-scoped", Now: func() time.Time { return now }}).Evaluate(context.Background(), ProfileAct)
+	if err != nil || !result.Eligible || authenticated != 2 {
+		t.Fatalf("anonymous fallback = %#v, authenticated requests=%d, error=%v", result, authenticated, err)
+	}
+}
+
+func TestUpstreamGateRetriesTransientTransportFailure(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return nil, context.DeadlineExceeded
+	})}
+	_, err := (UpstreamGateClient{HTTPClient: client}).Evaluate(context.Background(), ProfileAct)
+	if !errors.Is(err, context.DeadlineExceeded) || attempts != 3 {
+		t.Fatalf("transport retries = %d, error=%v", attempts, err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func upstreamRunsFixture(completedAt time.Time, event, status, conclusion string) string {
+	createdAt := completedAt.Add(-time.Hour)
+	return fmt.Sprintf(`{"workflow_runs":[{"id":42,"run_attempt":1,"event":%q,"status":%q,"conclusion":%q,"head_branch":"master","head_sha":"%s","created_at":"%s","updated_at":"%s"}]}`, event, status, conclusion, strings.Repeat("a", 40), createdAt.Format(time.RFC3339), completedAt.Format(time.RFC3339))
+}
+
+func upstreamFixtureClient(t *testing.T, runs, jobs string, status int) (UpstreamGateClient, func()) {
+	t.Helper()
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if status != http.StatusOK {
+			response.WriteHeader(status)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "/actions/runs/") {
+			_, _ = response.Write([]byte(jobs))
+			return
+		}
+		_, _ = response.Write([]byte(runs))
+	}))
+	return UpstreamGateClient{HTTPClient: server.Client(), BaseURL: server.URL, Now: func() time.Time { return now }}, server.Close
+}

--- a/scripts/docker-sandboxes/validate-prebuilt.ps1
+++ b/scripts/docker-sandboxes/validate-prebuilt.ps1
@@ -25,7 +25,7 @@ function Assert-Contains {
     }
 }
 
-Assert-Equal 'prebuilt lock schema' $lock.schemaVersion 2
+Assert-Equal 'prebuilt lock schema' $lock.schemaVersion 3
 Assert-Equal 'prebuilt artifact kind' $lock.artifactKind 'docker-sandboxes-template-base'
 Assert-Equal 'runtime contract' $lock.runtimeContract 'docker-sandboxes-v1'
 Assert-Equal 'template schema' $lock.templateSchema 2
@@ -54,16 +54,19 @@ Assert-Equal 'runner selector' $lock.runner.selector 'latest'
 Assert-Equal 'runner resolution' $lock.runner.assetResolution 'actions-release-descriptor'
 Assert-Equal 'runner source' $lock.runner.assetSource 'github-actions-runner-release'
 Assert-Equal 'runner overlay' $lock.runner.overlayRequired $false
-Assert-Equal 'runner promotion' $lock.runner.promotion 'manual-on-tuple-change'
+Assert-Equal 'runner promotion' $lock.runner.promotion 'automatic-on-compatible-v1'
 
 $sourceLockPath = Join-Path $templateDirectory $lock.sourceLock
 if (-not (Test-Path -LiteralPath $sourceLockPath -PathType Leaf)) {
     throw "static source lock is missing: $sourceLockPath"
 }
-foreach ($requiredEvidence in @('provenance', 'sbom', 'attestation', 'platform-runtime', 'sandbox-import-readback')) {
+foreach ($requiredEvidence in @('provenance', 'sbom', 'attestation', 'platform-runtime', 'upstream-workflow')) {
     if (-not @($lock.requiredEvidence) -contains $requiredEvidence) {
         throw "required evidence is missing: $requiredEvidence"
     }
+}
+if (-not @($lock.protectedPromotionEvidence) -contains 'sandbox-import-readback') {
+    throw 'protected promotion evidence is missing: sandbox-import-readback'
 }
 
 $dockerfilePath = Join-Path $templateDirectory 'Dockerfile.prebuilt'

--- a/templates/docker-sandboxes/prebuilt.lock.json
+++ b/templates/docker-sandboxes/prebuilt.lock.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "artifactKind": "docker-sandboxes-template-base",
   "packageRepository": "ghcr.io/solutionforest/ephemeral-action-runner/docker-sandboxes-template",
   "runtimeContract": "docker-sandboxes-v1",
@@ -30,7 +30,7 @@
     "assetResolution": "actions-release-descriptor",
     "assetSource": "github-actions-runner-release",
     "overlayRequired": false,
-    "promotion": "manual-on-tuple-change"
+    "promotion": "automatic-on-compatible-v1"
   },
   "verifiedBuildInputs": {
     "runnerArchive": "inputs/actions-runner.tar.gz",
@@ -57,6 +57,9 @@
     "sbom",
     "attestation",
     "platform-runtime",
+    "upstream-workflow"
+  ],
+  "protectedPromotionEvidence": [
     "sandbox-import-readback"
   ]
 }


### PR DESCRIPTION
## Summary

- promote the reviewed runtime-contract compatibility model and narrowed artifact recipe identity from develop
- enable fresh-upstream-gated automatic Act and Full candidate promotion while preserving signed provenance and explicit revocation
- retain candidate-only behavior for force-candidate runs and runtime-major transitions

## Evidence

- feature PR #40 was squash-merged to develop
- all feature PR checks passed across Linux, Windows, macOS, race/vet, trust rotation, core canaries, and the prebuilt publication contract
- built-in GitHub Actions token access to upstream workflow metadata was proven live
- Act and Full no-alias probes passed; Full completed both platform builds, hosted smoke checks, attestations, signing, and candidate publication
- act-latest, full-latest, and catalog-v1 remained unchanged during the probes

## Main-branch behavior

After merge, the workflow may automatically advance a compatible v1 profile alias only when the corresponding upstream evidence and hosted checks are green. Catalog-first and profile-alias-last ordering remains enforced.